### PR TITLE
fixDRM_#197

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,21 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>1.4</version>
+          <executions>
+            <execution>
+              <id>enforce-maven</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>3.3.9</version>
+                  </requireMavenVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- Produce jar files -->
@@ -445,14 +460,8 @@
         <plugin>
           <groupId>com.simpligility.maven.plugins</groupId>
           <artifactId>android-maven-plugin</artifactId>
-          <version>4.3.0</version>
+          <version>4.4.1</version>
           <extensions>true</extensions>
-        </plugin>
-
-        <plugin>
-          <groupId>com.jayway.maven.plugins.android.generation2</groupId>
-          <artifactId>android-maven-plugin</artifactId>
-          <version>4.0.0-rc.2</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
required maven version 3.3.9 or later for drm libraries to be added to the target

updated maven plugin version
removed duplicate (outdated) android maven plugin

Fixes #197 