### PR TITLE
optimizeNavigationStack_#206

### DIFF
--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/SimplifiedActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/SimplifiedActivity.java
@@ -158,8 +158,64 @@ public abstract class SimplifiedActivity extends Activity
        * transition animation.
        */
 
-      this.finishWithConditionalAnimationOverride();
+
+      if (SimplifiedActivity.ACTIVITY_COUNT == 1)
+      {
+
+        if (this.getClass() != MainCatalogActivity.class ) {
+          // got to main catalog activity
+          //final DrawerLayout d = NullCheck.notNull(this.drawer);
+          this.selected = 0;
+          startSideBarActivity();
+
+
+        }
+        else
+        {
+          d.openDrawer(GravityCompat.START);
+        }
+      }
+      else {
+        this.finishWithConditionalAnimationOverride();
+      }
     }
+  }
+
+  private void startSideBarActivity() {
+    if (this.selected != -1) {
+      final List<SimplifiedPart> di = NullCheck.notNull(this.drawer_items);
+      final Map<SimplifiedPart, Class<? extends Activity>> dc =
+              NullCheck.notNull(this.drawer_classes_by_name);
+      final Map<SimplifiedPart, FunctionType<Bundle, Unit>> fas =
+              NullCheck.notNull(this.drawer_arg_funcs);
+
+      final SimplifiedPart name = NullCheck.notNull(di.get(this.selected));
+      final Class<? extends Activity> c = NullCheck.notNull(dc.get(name));
+      final FunctionType<Bundle, Unit> fa = NullCheck.notNull(fas.get(name));
+
+      final Bundle b = new Bundle();
+      SimplifiedActivity.setActivityArguments(b, false);
+      fa.call(b);
+
+      final Intent i = new Intent();
+      i.setClass(this, c);
+      i.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+
+      //TODO AM: // reset menu // temporary fix
+      i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+      i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+      i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+
+      i.putExtras(b);
+      this.startActivity(i);
+
+      //TODO AM: // hide task transitions // temporary fix
+      this.overridePendingTransition(0, 0);
+
+    }
+    this.selected = -1;
+
   }
 
   @Override protected void onCreate(
@@ -466,29 +522,8 @@ public abstract class SimplifiedActivity extends Activity
      * relevant activity.
      */
 
-    if (this.selected != -1) {
-      final List<SimplifiedPart> di = NullCheck.notNull(this.drawer_items);
-      final Map<SimplifiedPart, Class<? extends Activity>> dc =
-        NullCheck.notNull(this.drawer_classes_by_name);
-      final Map<SimplifiedPart, FunctionType<Bundle, Unit>> fas =
-        NullCheck.notNull(this.drawer_arg_funcs);
+    startSideBarActivity();
 
-      final SimplifiedPart name = NullCheck.notNull(di.get(this.selected));
-      final Class<? extends Activity> c = NullCheck.notNull(dc.get(name));
-      final FunctionType<Bundle, Unit> fa = NullCheck.notNull(fas.get(name));
-
-      final Bundle b = new Bundle();
-      SimplifiedActivity.setActivityArguments(b, false);
-      fa.call(b);
-
-      final Intent i = new Intent();
-      i.setClass(this, c);
-      i.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-      i.putExtras(b);
-      this.startActivity(i);
-    }
-
-    this.selected = -1;
   }
 
   @Override public final void onDrawerOpened(

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/WebViewActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/WebViewActivity.java
@@ -115,6 +115,7 @@ public final class WebViewActivity extends SimplifiedActivity
 
     final ActionBar bar = this.getActionBar();
     bar.setTitle(title);
+    bar.setHomeAsUpIndicator(R.drawable.ic_drawer);
     bar.setDisplayHomeAsUpEnabled(true);
     bar.setHomeButtonEnabled(true);
 
@@ -128,25 +129,5 @@ public final class WebViewActivity extends SimplifiedActivity
     settings.setBlockNetworkLoads(true);
 
     this.web_view.loadUrl(uri);
-  }
-
-  @Override public boolean onOptionsItemSelected(
-    final @Nullable MenuItem item_mn)
-  {
-    final MenuItem item = NullCheck.notNull(item_mn);
-    switch (item.getItemId()) {
-
-      /**
-       * Configure the home button to finish the activity.
-       */
-
-      case android.R.id.home: {
-        this.finish();
-        this.overridePendingTransition(0, 0);
-        return true;
-      }
-    }
-
-    return super.onOptionsItemSelected(item);
   }
 }

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogActivity.java
@@ -9,6 +9,7 @@ import com.io7m.jfunctional.Pair;
 import com.io7m.jnull.NullCheck;
 import com.io7m.jnull.Nullable;
 import com.io7m.junreachable.UnreachableCodeException;
+import org.nypl.simplified.app.R;
 import org.nypl.simplified.app.SimplifiedActivity;
 import org.nypl.simplified.app.utilities.FadeUtilities;
 import org.nypl.simplified.books.core.LogUtilities;
@@ -55,6 +56,7 @@ public abstract class CatalogActivity extends SimplifiedActivity
 
     final ActionBar bar = this.getActionBar();
     if (up_stack.isEmpty() == false) {
+      bar.setHomeAsUpIndicator(R.drawable.ic_drawer);
       bar.setDisplayHomeAsUpEnabled(true);
       bar.setHomeButtonEnabled(true);
     }
@@ -77,47 +79,6 @@ public abstract class CatalogActivity extends SimplifiedActivity
     final ImmutableStack<CatalogFeedArgumentsType> empty =
       ImmutableStack.empty();
     return NullCheck.notNull(empty);
-  }
-
-  @Override public boolean onOptionsItemSelected(
-    final @Nullable MenuItem item_mn)
-  {
-    final MenuItem item = NullCheck.notNull(item_mn);
-    switch (item.getItemId()) {
-
-      /**
-       * Configure the home button to start a new activity with a popped
-       * up-stack.
-       */
-
-      case android.R.id.home: {
-        final ImmutableStack<CatalogFeedArgumentsType> us = this.getUpStack();
-
-        /**
-         * If the stack is non-empty, then the user is not at the root of the
-         * catalog. If it is empty, then the button is only enabled to control
-         * the navigation drawer and therefore the event should be propagated.
-         */
-
-        if (us.isEmpty() == false) {
-          CatalogActivity.LOG.debug("up stack before pop: {}", us);
-
-          final Pair<CatalogFeedArgumentsType,
-            ImmutableStack<CatalogFeedArgumentsType>>
-            p = us.pop();
-
-          final CatalogFeedArgumentsType top = p.getLeft();
-          this.catalogActivityForkNew(top);
-          return true;
-        }
-
-        return super.onOptionsItemSelected(item);
-      }
-
-      default: {
-        return super.onOptionsItemSelected(item);
-      }
-    }
   }
 
   @Override protected void onResume()

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogBookDetailActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogBookDetailActivity.java
@@ -1,5 +1,6 @@
 package org.nypl.simplified.app.catalog;
 
+import android.app.ActionBar;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -139,7 +140,8 @@ public final class CatalogBookDetailActivity extends CatalogActivity
       new CatalogBookDetailView(this, inflater, this.getFeedEntry());
     this.view = detail_view;
     this.part = this.getPart();
-    this.navigationDrawerSetActionBarTitle();
+    final ActionBar bar = this.getActionBar();
+    bar.setTitle("Details");
 
     final FrameLayout content_area = this.getContentFrame();
     content_area.removeAllViews();

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogBookReportActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogBookReportActivity.java
@@ -63,6 +63,7 @@ public class CatalogBookReportActivity extends SimplifiedActivity
   private void configureUpButton()
   {
     final ActionBar bar = this.getActionBar();
+    bar.setHomeAsUpIndicator(R.drawable.ic_drawer);
     bar.setDisplayHomeAsUpEnabled(true);
     bar.setHomeButtonEnabled(true);
     bar.setTitle(this.getResources().getString(R.string.catalog_book_report));
@@ -150,29 +151,6 @@ public class CatalogBookReportActivity extends SimplifiedActivity
         CatalogBookReportActivity.this.submitReport();
       }
     });
-  }
-
-  @Override public boolean onOptionsItemSelected(
-    final @Nullable MenuItem item_mn)
-  {
-    final MenuItem item = NullCheck.notNull(item_mn);
-    switch (item.getItemId()) {
-
-      /**
-       * Configure the home button to simply close this activity.
-       */
-
-      case android.R.id.home: {
-        this.finish();
-        this.overridePendingTransition(0, 0);
-
-        return true;
-      }
-
-      default: {
-        return super.onOptionsItemSelected(item);
-      }
-    }
   }
 
   private void submitReport()

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogFeedActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogFeedActivity.java
@@ -453,6 +453,7 @@ public abstract class CatalogFeedActivity extends CatalogActivity implements
   {
     final ActionBar bar = this.getActionBar();
     if (up_stack.isEmpty() == false) {
+      bar.setHomeAsUpIndicator(R.drawable.ic_drawer);
       bar.setDisplayHomeAsUpEnabled(true);
       bar.setHomeButtonEnabled(true);
       bar.setTitle(title);

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/testing/AlternateFeedURIsActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/testing/AlternateFeedURIsActivity.java
@@ -62,6 +62,7 @@ public final class AlternateFeedURIsActivity extends SimplifiedActivity
     super.onCreate(state);
 
     final ActionBar bar = this.getActionBar();
+    bar.setHomeAsUpIndicator(R.drawable.ic_drawer);
     bar.setDisplayHomeAsUpEnabled(true);
     bar.setHomeButtonEnabled(true);
     bar.setTitle("Alternate URIs");


### PR DESCRIPTION
- Home button opens and closes the sidebar drawer
- Device back button navigates through the stack of activities
- Each sidebar option starts a new navigation stack
- using device back button works as expected, unstackig each activity to the root activity of the section,
	- using back button at root activity for each section goes back to the catalog
	- using the back button at catalog level will show the sidebar menu
	- using the back button one more time, will close the app.

Fixes #206 