### PR TITLE
excluding R.java from javadoc generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,6 +539,10 @@
                   <Built-By>NYPL Labs</Built-By>
                 </manifestEntries>
               </archive>
+              <sourcepath>${basedir}/target/generated-sources</sourcepath>
+              <sourceFileExcludes>
+                <exclude>**/R.java</exclude>
+              </sourceFileExcludes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Fixes #192 