### PR TITLE
Removed length limit from PIN field

### DIFF
--- a/simplified-app-shared/src/main/res/layout/login_dialog.xml
+++ b/simplified-app-shared/src/main/res/layout/login_dialog.xml
@@ -76,7 +76,6 @@
         android:layout_weight="1"
         android:inputType="textNoSuggestions"
         android:minWidth="160dp"
-        android:maxLength="4"
         android:maxLines="1">
       </EditText>
     </TableRow>


### PR DESCRIPTION
This addresses a use-case for Alameda county, where their patrons
are currently logging in using their last names rather than a 4-digit
number.