### PR TITLE
Add location saving on activity pause

### DIFF
--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
@@ -526,6 +526,17 @@ public final class ReaderActivity extends Activity implements
     }
   }
 
+  @Override protected void onPause()
+  {
+    super.onPause();
+
+    final SimplifiedReaderAppServicesType rs = Simplified.getReaderAppServices();
+
+    if (this.book_id != null && this.current_location != null) {
+      rs.getBookmarks().setBookmark(this.book_id, this.current_location);
+    }
+  }
+
   @Override protected void onDestroy()
   {
     super.onDestroy();


### PR DESCRIPTION
This fixes an issue where the reader's last location would not be saved if the app was killed while in the background.