### PR TITLE
Non-drm returns #455

### DIFF
--- a/simplified-books-core/src/main/java/org/nypl/simplified/books/core/BooksControllerRevokeBookTask.java
+++ b/simplified-books-core/src/main/java/org/nypl/simplified/books/core/BooksControllerRevokeBookTask.java
@@ -381,26 +381,26 @@ final class BooksControllerRevokeBookTask
         returnBookWithoutDRM(snap, revoke_uri);
       }
 
+      /**
+       * If it turns out that the loan is not actually returnable, well, there's
+       * nothing we can do about that. This is a bug in the program.
+       */
+
+      final AdobeAdeptLoan loan = ((Some<AdobeAdeptLoan>) loan_opt).get();
+      if (loan.isReturnable() == true) {
+
         /**
-         * If it turns out that the loan is not actually returnable, well, there's
-         * nothing we can do about that. This is a bug in the program.
+         * Execute a task using the Adobe DRM library, and wait for it to
+         * finish. The reason for the waiting, as opposed to calling further
+         * methods from inside the listener callbacks is to avoid any chance
+         * of the methods in question propagating an unchecked exception back
+         * to the native code. This will obviously crash the whole process,
+         * rather than just failing the revocation.
          */
 
-        final AdobeAdeptLoan loan = ((Some<AdobeAdeptLoan>) loan_opt).get();
-        if (loan.isReturnable() == true) {
-
-          /**
-           * Execute a task using the Adobe DRM library, and wait for it to
-           * finish. The reason for the waiting, as opposed to calling further
-           * methods from inside the listener callbacks is to avoid any chance
-           * of the methods in question propagating an unchecked exception back
-           * to the native code. This will obviously crash the whole process,
-           * rather than just failing the revocation.
-           */
-
-          final CountDownLatch latch = new CountDownLatch(1);
-          final AdobeLoanReturnResult listener = new AdobeLoanReturnResult(latch);
-          adobe.execute(
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AdobeLoanReturnResult listener = new AdobeLoanReturnResult(latch);
+        adobe.execute(
             new AdobeAdeptProcedureType()
             {
               @Override public void executeWith(final AdobeAdeptConnectorType c)

--- a/simplified-books-core/src/main/java/org/nypl/simplified/books/core/BooksControllerRevokeBookTask.java
+++ b/simplified-books-core/src/main/java/org/nypl/simplified/books/core/BooksControllerRevokeBookTask.java
@@ -371,15 +371,15 @@ final class BooksControllerRevokeBookTask
         this.books_database.databaseOpenEntryForReading(this.book_id);
       final BookDatabaseEntrySnapshot snap = er.entryGetSnapshot();
 
-        /**
-         * If the loan information is gone, well, there's nothing we can
-         * do about that. This is a bug in the program.
-         */
+      /**
+       * If the loan information is gone, it's assumed that it is a non-drm
+       * book from a library that still needs to be "returned"
+       */
 
-        final OptionType<AdobeAdeptLoan> loan_opt = snap.getAdobeRights();
-        if (loan_opt.isNone()) {
-          throw new UnreachableCodeException();
-        }
+      final OptionType<AdobeAdeptLoan> loan_opt = snap.getAdobeRights();
+      if (loan_opt.isNone()) {
+        returnBookWithoutDRM(snap, revoke_uri);
+      }
 
         /**
          * If it turns out that the loan is not actually returnable, well, there's
@@ -465,6 +465,25 @@ final class BooksControllerRevokeBookTask
       final OptionType<Throwable> no_exception = Option.none();
       this.revokeFailed(no_exception, "DRM is not supported!");
     }
+  }
+
+  public void returnBookWithoutDRM(final BookDatabaseEntrySnapshot snapshot, final URI revoke_uri)
+    throws IOException
+  {
+    /**
+     * Save the "revoked" state of the book.
+     * Finish the revocation by telling the server about it.
+     */
+
+    final OPDSAcquisitionFeedEntryBuilderType b =
+        OPDSAcquisitionFeedEntry.newBuilderFrom(snapshot.getEntry());
+    b.setAvailability(OPDSAvailabilityRevoked.get(revoke_uri));
+    final OPDSAcquisitionFeedEntry ee = b.build();
+    final BookDatabaseEntryWritableType ew =
+        this.books_database.databaseOpenEntryForWriting(this.book_id);
+    ew.entrySetFeedData(ee);
+
+    this.revokeUsingURI(revoke_uri, RevokeType.LOAN);
   }
 
   @Override public Unit onLoanable(final OPDSAvailabilityLoanable a)


### PR DESCRIPTION
If a user has a non-DRM book from a particular book provider that shows an entry with a generic acquisition link, the UI as far as I can tell still treats it like a "DRM" title. (Showing "return" instead of just "delete" which is correct).

If a user tries to return one of these titles, the client should still ping the server with the revoke link.

On iOS, the client correctly bypasses any DRM code when trying to return, and still hits the server.
On Android, it does not expect to encounter a title with no fulfillment id (adobe auth data) under these conditions, so the app throws an exception (and the UI hangs).

For now I've simply matched the logic on iOS to allow loan returns, but it feels like there's probably a need for a new Type attribute that hadn't been considered up to this point. This was discovered as part of the testing with Datalogics and adding support for Enki titles.

resolves #455 