### PR TITLE
DRM Workflow Edge Case on returning RBdigital books (Android only)

### DIFF
--- a/simplified-books-core/src/main/java/org/nypl/simplified/books/core/BooksControllerRevokeBookTask.java
+++ b/simplified-books-core/src/main/java/org/nypl/simplified/books/core/BooksControllerRevokeBookTask.java
@@ -558,8 +558,9 @@ final class BooksControllerRevokeBookTask
         if (in_error.startsWith("E_ACT_NOT_READY")) {
           this.error = Option.some((Throwable) new AccountNotReadyException(in_error));
         }
+        // Known issue of 404 URL for OneClick/RBdigital books
         else if (in_error.startsWith("E_STREAM_ERROR")) {
-          BooksControllerRevokeBookTask.LOG.debug("E_STREAM_ERROR returned from DRM Workflow. Continuing by attempting to revoke book manually.");
+          BooksControllerRevokeBookTask.LOG.debug("E_STREAM_ERROR: Ignore and continue with return.");
           this.error = Option.none();
         }
         else {

--- a/simplified-books-core/src/main/java/org/nypl/simplified/books/core/BooksControllerRevokeBookTask.java
+++ b/simplified-books-core/src/main/java/org/nypl/simplified/books/core/BooksControllerRevokeBookTask.java
@@ -558,6 +558,10 @@ final class BooksControllerRevokeBookTask
         if (in_error.startsWith("E_ACT_NOT_READY")) {
           this.error = Option.some((Throwable) new AccountNotReadyException(in_error));
         }
+        else if (in_error.startsWith("E_STREAM_ERROR")) {
+          BooksControllerRevokeBookTask.LOG.debug("E_STREAM_ERROR returned from DRM Workflow. Continuing by attempting to revoke book manually.");
+          this.error = Option.none();
+        }
         else {
           this.error = Option.some((Throwable) new BookRevokeExceptionDRMWorkflowError(in_error));
         }


### PR DESCRIPTION
fixes #471 

During the round trip between adobe, the distributor, and our circ servers during a Loan Return, the process stalls when trying to hit a dead URL for RBDigital (URL is in linked issue). The workflow spits back up an error of "E_STREAM_ERROR HTTP response code 404".

The adobe library on iOS does not have any issue with returns, and I can't explain why without any data coming out of the library. (I suppose we could sniff internet traffic if we really wanted to know).

Since the book has successfully been returned as far as Adobe is concerned, the effect is that the book remains in the patron's loans, but is fully encrypted. It is believed at this point that all that's required is for the "revoke" link to be hit with a GET request. The change in the client is to essentially filter for this error and perform the revoke request (last step) anyway.

@winniequinn @daryanypl 
I feel confident in the step to correct, but the review is mainly for the CONDITIONS in which the app should be doing this. One point that Leonard brings up is that it's essentially "safe" to perform this revoke request from our end:
>you can hit /revoke on an adobe-encrypted book at any time without doing permanent damage
because the source of truth w/r/t the loan is not the circulation manager

Although the potential danger is if E_STREAM_ERROR comes out of the box so often that we end up with a sizable number of false positives for this condition. Which would be a lot of books waiting for expirations that could not be checked out by an patrons.

I think this risk is low with my experience in workflow errors (@winniequinn), but one other option I could see is also restricting to `distributor == RBdigital` though getting that book property to propagate down to the proper listener would probably be kind of messy.