### PR TITLE
Allow the PIN field's length and type to be configurable

### DIFF
--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/LoginDialog.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/LoginDialog.java
@@ -8,6 +8,8 @@ import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.InputFilter;
+import android.text.InputType;
 import android.text.TextWatcher;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -360,7 +362,17 @@ public final class LoginDialog extends DialogFragment
     final CheckBox in_eula_checkbox =
       NullCheck.notNull((CheckBox) in_layout.findViewById(R.id.eula_checkbox));
 
-
+    Account currAcct = Simplified.getCurrentAccount();
+    if(currAcct != null){
+      if (currAcct.getPinLength() != null && currAcct.getPinLength() != 0) {
+        InputFilter[] fArray = new InputFilter[1];
+        fArray[0] = new InputFilter.LengthFilter(currAcct.getPinLength());
+        in_pin_edit.setFilters(fArray);
+      }
+      if (!currAcct.getPinLetters()) {
+        in_pin_edit.setInputType(InputType.TYPE_CLASS_NUMBER);
+      }
+  }
 
 
     final Button in_login_request_new_code = NullCheck.notNull(

--- a/simplified-multilibrary/src/main/java/org/nypl/simplified/multilibrary/Account.java
+++ b/simplified-multilibrary/src/main/java/org/nypl/simplified/multilibrary/Account.java
@@ -41,6 +41,8 @@ public class Account implements Serializable {
   private String eula;
   private String content_license;
   private String privacy_policy;
+  private Integer pin_length;
+  private boolean pin_letters;
   private String catalog_url_under_13;
   private String catalog_url_13_and_over;
 
@@ -58,6 +60,9 @@ public class Account implements Serializable {
   public String getEula() {
     return eula;
   }
+
+  public Integer getPinLength() { return pin_length; }
+  public boolean getPinLetters() { return pin_letters; }
 
 
   public void setContentLicense(String in_contentLicense) {
@@ -336,6 +341,12 @@ public class Account implements Serializable {
         this.content_license = account.getString("licenseUrl");
       }
 
+      if (!account.isNull("authPasscodeLength")) {
+        this.pin_length = account.getInt("authPasscodeLength");
+      }
+      if (!account.isNull("authPasscodeAllowsLetters")) {
+        this.pin_letters = account.getBoolean("authPasscodeAllowsLetters");
+      }
 
     } catch (JSONException e) {
       e.printStackTrace();

--- a/simplified-multilibrary/src/main/java/org/nypl/simplified/multilibrary/Account.java
+++ b/simplified-multilibrary/src/main/java/org/nypl/simplified/multilibrary/Account.java
@@ -11,11 +11,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 
-/**
- * Created by aferditamuriqi on 8/29/16.
- *
- */
-
 public class Account implements Serializable {
 
   private Integer id;
@@ -30,40 +25,32 @@ public class Account implements Serializable {
   private boolean supports_reservations;
   private boolean supports_card_creator;
   private boolean supports_help_center;
-
   private String support_email;
-
   private String card_creator_url;
-
   private String catalog_url;
   private String main_color;
-
   private String eula;
   private String content_license;
   private String privacy_policy;
-  private Integer pin_length;
-  private boolean pin_letters;
   private String catalog_url_under_13;
   private String catalog_url_13_and_over;
+  private Integer pin_length;
+  private boolean pin_allows_letters;
 
   public String getPrivacyPolicy() {
     return privacy_policy;
   }
-
   public String getContentLicense() {
     return content_license;
   }
   public String getSupportEmail() {
     return support_email;
   }
-
   public String getEula() {
     return eula;
   }
-
   public Integer getPinLength() { return pin_length; }
-  public boolean getPinLetters() { return pin_letters; }
-
+  public boolean pinAllowsLetters() { return pin_allows_letters; }
 
   public void setContentLicense(String in_contentLicense) {
     this.content_license = in_contentLicense;
@@ -224,7 +211,6 @@ public class Account implements Serializable {
     this.supports_reservations = supports_reservations;
   }
 
-
   /**
    * @return
    */
@@ -267,7 +253,6 @@ public class Account implements Serializable {
     this.supports_simplye_sync = supports_simplye_sync;
   }
 
-
   /**
    * @return
    */
@@ -283,12 +268,10 @@ public class Account implements Serializable {
   }
 
 
-
   /**
    * @param account The Json Account
    */
   public Account(final JSONObject account) {
-
 
     try {
       this.id = account.getInt("id");
@@ -306,9 +289,15 @@ public class Account implements Serializable {
       if (!account.isNull("cardCreatorUrl")) {
         this.card_creator_url = account.getString("cardCreatorUrl");
       }
-      this.needs_auth = account.getBoolean("needsAuth");
-      this.supports_reservations = account.getBoolean("supportsReservations");
-      this.supports_card_creator = account.getBoolean("supportsCardCreator");
+      if (!account.isNull("needsAuth")) {
+        this.needs_auth = account.getBoolean("needsAuth");
+      }
+      if (!account.isNull("supportsReservations")) {
+        this.supports_reservations = account.getBoolean("supportsReservations");
+      }
+      if (!account.isNull("supportsCardCreator")) {
+        this.supports_card_creator = account.getBoolean("supportsCardCreator");
+      }
       if (!account.isNull("supportsSimplyESync")) {
         this.supports_simplye_sync = account.getBoolean("supportsSimplyESync");
       }
@@ -321,16 +310,12 @@ public class Account implements Serializable {
       if (!account.isNull("supportsBarcodeDisplay")) {
         this.supports_barcode_display = account.getBoolean("supportsBarcodeDisplay");
       }
-
       if (!account.isNull("supportEmail")) {
         this.support_email = account.getString("supportEmail");
       }
-
       if (!account.isNull("mainColor")) {
         this.main_color = account.getString("mainColor");
       }
-
-
       if (!account.isNull("eulaUrl")) {
         this.eula = account.getString("eulaUrl");
       }
@@ -340,12 +325,15 @@ public class Account implements Serializable {
       if (!account.isNull("licenseUrl")) {
         this.content_license = account.getString("licenseUrl");
       }
-
       if (!account.isNull("authPasscodeLength")) {
         this.pin_length = account.getInt("authPasscodeLength");
+      } else {
+        this.pin_length = 0;
       }
       if (!account.isNull("authPasscodeAllowsLetters")) {
-        this.pin_letters = account.getBoolean("authPasscodeAllowsLetters");
+        this.pin_allows_letters = account.getBoolean("authPasscodeAllowsLetters");
+      } else {
+        this.pin_allows_letters = true;
       }
 
     } catch (JSONException e) {
@@ -380,6 +368,8 @@ public class Account implements Serializable {
       object.put("supportsSimplyESync", this.supports_simplye_sync);
       object.put("supportsBarcodeScanner", this.supports_barcode_scanner);
       object.put("supportsBarcodeDisplay", this.supports_barcode_display);
+      object.put("authPasscodeLength", this.pin_length);
+      object.put("authPasscodeAllowsLetters", this.pin_allows_letters);
       object.put("mainColor", this.main_color);
     } catch (JSONException e) {
       e.printStackTrace();


### PR DESCRIPTION
Two new fields can be parsed from Accounts.json - pin length and pin
type. By default, it will be unlimited and numbers only.

This commit does not fully implement this feature. Reading the config
doesn't work right when done from the accounts screen.