### PR TITLE
Fix color for SimplyE collection

### DIFF
--- a/simplified-app-shared/src/main/res/values/features.xml
+++ b/simplified-app-shared/src/main/res/values/features.xml
@@ -8,7 +8,7 @@
   <drawable name="feature_app_splash">@drawable/simplified_splash</drawable>
 
 
-  <color name="app_main_color">#666766</color>
+  <color name="app_main_color">#497049</color>
 
   <!-- The configurable main color, used for branding. -->
   <color name="feature_main_color">#497049</color>


### PR DESCRIPTION
This is a hack, but the whole approach to branding and colors needs to be redone anyway. There's no nice way to fix this for now. Refactoring the branding will be done as part of the library registry work.