### PR TITLE
Fix Saving Page Position at onPause()

### DIFF
--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
@@ -502,6 +502,8 @@ public final class ReaderActivity extends Activity implements
   @Override public void onCurrentPageReceived(
     final ReaderBookLocation l)
   {
+    this.current_location = l;
+
     ReaderActivity.LOG.debug("received book location: {}", l);
 
     if (Simplified.getSharedPrefs().getBoolean("setting_sync_last_read") && Simplified.getCurrentAccount().supportsSimplyESync()) {


### PR DESCRIPTION
Update current page instance var to correctly write position to sharedPrefs() during onPause()