### PR TITLE
Upgrade Gradle Android tools to 3.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
   repositories {
+    google()
     jcenter()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:3.0.1'
     classpath 'com.netflix.nebula:gradle-lint-plugin:7.4.0'
     classpath 'com.nabilhachicha:android-native-dependencies:0.1.2'
   }


### PR DESCRIPTION
This upgrades the Android Gradle tools to 3.0.1. Android Studio doesn't stop complaining unless you do this!