### PR TITLE
Correct a credentials race

### DIFF
--- a/simplified-books-core/src/main/java/org/nypl/simplified/books/core/BooksControllerLoginTask.java
+++ b/simplified-books-core/src/main/java/org/nypl/simplified/books/core/BooksControllerLoginTask.java
@@ -161,8 +161,6 @@ final class BooksControllerLoginTask implements Runnable,
     BooksControllerLoginTask.LOG.debug(
       "logged in as {} successfully", this.credentials.getBarcode());
 
-    this.books.accountSync(this.listener, this.device_listener);
-
     try {
       this.accounts_database.accountSetCredentials(this.credentials);
     } catch (final IOException e) {
@@ -172,6 +170,7 @@ final class BooksControllerLoginTask implements Runnable,
       return;
     }
 
+    this.books.accountSync(this.listener, this.device_listener);
   }
 
   @Override


### PR DESCRIPTION
On login success, the existing code immediately schedules a sync
of the account's books. It then saves the credentials that were
received as being correct. The problem here is that the sync task
can run before the credentials have been saved and therefore the 
task will immediately fail.

The simple fix is to save the credentials first.