### PR TITLE
Add will-change property for page turn performance

### DIFF
--- a/simplified-app-shared/src/main/assets/simplified.js
+++ b/simplified-app-shared/src/main/assets/simplified.js
@@ -83,7 +83,8 @@ function Simplified() {
     contentDocument.removeEventListener("touchend", handleTouchEnd);
     contentDocument.addEventListener("touchend", handleTouchEnd, false);
     // Set up the page turning animation.
-    contentDocument.documentElement.style["transition"] = "left 0.2s" ;
+    contentDocument.documentElement.style["transition"] = "left 0.2s";
+    contentDocument.documentElement.style["will-change"] = "left";
   };
 
 }


### PR DESCRIPTION
Adding this one line tells the browser to expect the `left` property to change (which is how Readium handles page turning). This allows the browser to set things up in advance to achieve better performance whenever the property is altered.