### PR TITLE
Compile to implement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.1'
+    classpath 'com.android.tools.build:gradle:3.1.0'
     classpath 'com.netflix.nebula:gradle-lint-plugin:7.4.0'
     classpath 'com.nabilhachicha:android-native-dependencies:0.1.2'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.2.21'
+  ext.kotlin_version = '1.2.30'
   repositories {
     google()
     jcenter()

--- a/simplified-app-openebooks/build.gradle
+++ b/simplified-app-openebooks/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
   packagingOptions {
     exclude 'META-INF/LICENSE'
   }

--- a/simplified-app-openebooks/build.gradle
+++ b/simplified-app-openebooks/build.gradle
@@ -11,5 +11,5 @@ android {
 description = 'simplified-app-openebooks'
 
 dependencies {
-  compile project(':simplified-app-shared')
+  implementation project(':simplified-app-shared')
 }

--- a/simplified-app-shared/build.gradle
+++ b/simplified-app-shared/build.gradle
@@ -16,38 +16,43 @@ android {
 }
 
 dependencies {
-  compile project(':simplified-books-core')
-  compile project(':simplified-http-core')
-  compile project(':simplified-json-core')
-  compile project(':simplified-opds-core')
-  compile project(':simplified-stack')
-  compile project(':simplified-tenprint')
+  implementation project(':simplified-books-core')
+  implementation project(':simplified-http-core')
+  implementation project(':simplified-json-core')
+  implementation project(':simplified-opds-core')
+  implementation project(':simplified-stack')
+  implementation project(':simplified-tenprint')
   implementation project(':simplified-volley')
-  compile project(':simplified-prefs')
-  compile project(':simplified-multilibrary')
-  compile project(':simplified-circ-analytics')
-  compile project(':simplified-bugsnag')
-  compile project(':simplified-cardcreator')
+  implementation project(':simplified-prefs')
+  implementation project(':simplified-multilibrary')
+  implementation project(':simplified-circ-analytics')
+  implementation project(':simplified-bugsnag')
+  implementation project(':simplified-cardcreator')
+  implementation project(':simplified-assert')
+  implementation project(':simplified-files')
+  implementation project(':simplified-downloader-core')
 
-  compile group: 'org.nypl.drm', name: 'nypl-drm-core', version: '1.0.0'
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile "com.android.support:support-v4:27.0.2"
-  compile 'org.nypl.readium:readium-sdk-android-runtime:0.25.0'
-  compile 'org.nypl.readium:readium-shared-js:0.27.0'
-  compile 'com.koushikdutta.async:androidasync:2.2.1'
-  compile group: 'com.squareup.picasso', name: 'picasso', version: '2.5.2'
-  compile 'com.nanohttpd:nanohttpd:2.2.0'
-  compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-  compile 'org.nypl.helpstack:helpstack-android:1.4.0'
-  compile 'com.bugsnag:bugsnag-android:3.9.0'
-  compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
-  compile group: 'com.google.code.gson', name: 'gson', version: '2.8.1'
-  compile group: 'joda-time', name: 'joda-time', version: '2.9.9'
-  compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.2-b01'
-  compile 'com.github.ronaldsmartin:Material-ViewPagerIndicator:1.0.4'
+  implementation group: 'org.nypl.drm', name: 'nypl-drm-core', version: '1.0.0'
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation "com.android.support:support-v4:27.0.2"
+  implementation 'org.nypl.readium:readium-sdk-android-runtime:0.25.0'
+  implementation 'org.nypl.readium:readium-shared-js:0.27.0'
+  implementation 'com.koushikdutta.async:androidasync:2.2.1'
+  implementation group: 'com.squareup.picasso', name: 'picasso', version: '2.5.2'
+  implementation 'com.nanohttpd:nanohttpd:2.2.0'
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+  implementation 'org.nypl.helpstack:helpstack-android:1.4.0'
+  implementation 'com.bugsnag:bugsnag-android:3.9.0'
+  implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
+  implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.1'
+  implementation group: 'joda-time', name: 'joda-time', version: '2.9.9'
+  implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.2-b01'
+  implementation 'com.github.ronaldsmartin:Material-ViewPagerIndicator:1.0.4'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.6.0-rc3'
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
 
   implementation group: 'com.mcxiaoke.volley', name: 'library', version: '1.0.19'
+  implementation group: 'net.jodah', name: 'expiringmap', version: '0.4.3'
 }

--- a/simplified-app-shared/build.gradle
+++ b/simplified-app-shared/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
   useLibrary 'org.apache.http.legacy'
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
@@ -22,12 +22,13 @@ dependencies {
   compile project(':simplified-opds-core')
   compile project(':simplified-stack')
   compile project(':simplified-tenprint')
-  compile project(':simplified-volley')
+  implementation project(':simplified-volley')
   compile project(':simplified-prefs')
   compile project(':simplified-multilibrary')
   compile project(':simplified-circ-analytics')
   compile project(':simplified-bugsnag')
   compile project(':simplified-cardcreator')
+
   compile group: 'org.nypl.drm', name: 'nypl-drm-core', version: '1.0.0'
   compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
   compile "com.android.support:support-v4:27.0.2"
@@ -44,4 +45,9 @@ dependencies {
   compile group: 'joda-time', name: 'joda-time', version: '2.9.9'
   compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.2-b01'
   compile 'com.github.ronaldsmartin:Material-ViewPagerIndicator:1.0.4'
+
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.6.0-rc3'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
+
+  implementation group: 'com.mcxiaoke.volley', name: 'library', version: '1.0.19'
 }

--- a/simplified-app-shared/build.gradle
+++ b/simplified-app-shared/build.gradle
@@ -15,6 +15,10 @@ android {
   }
 }
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation project(':simplified-books-core')
   implementation project(':simplified-http-core')

--- a/simplified-app-simplye/build.gradle
+++ b/simplified-app-simplye/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
   packagingOptions {
     exclude 'META-INF/LICENSE'
   }

--- a/simplified-app-simplye/build.gradle
+++ b/simplified-app-simplye/build.gradle
@@ -27,10 +27,12 @@ android {
 description = 'simplified-app-simplye'
 
 dependencies {
-  compile project(':simplified-app-shared')
-  compile group: 'org.nypl.drm', name: 'nypl-drm-adobe-provider', version: '1.0.0'
-  compile group: 'org.nypl.drm', name: 'libnypl_adobe', version: '1.0.0'
-  compile group: 'org.nypl.drm', name: 'libnypl_adobe_filter', version: '1.0.0'
+  implementation project(':simplified-app-shared')
+  implementation group: 'org.nypl.drm', name: 'nypl-drm-adobe-provider', version: '1.0.0'
+  implementation group: 'org.nypl.drm', name: 'libnypl_adobe', version: '1.0.0'
+  implementation group: 'org.nypl.drm', name: 'libnypl_adobe_filter', version: '1.0.0'
+
+  implementation "com.android.support:support-v4:27.0.2"
 }
 
 apply plugin: 'android-native-dependencies'

--- a/simplified-app-tests/build.gradle
+++ b/simplified-app-tests/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
   packagingOptions {
     exclude 'META-INF/LICENSE'
   }

--- a/simplified-app-tests/build.gradle
+++ b/simplified-app-tests/build.gradle
@@ -11,5 +11,5 @@ android {
 description = 'simplified-app-tests'
 
 dependencies {
-  compile project(':simplified-app-shared')
+  implementation project(':simplified-app-shared')
 }

--- a/simplified-app-vanilla/build.gradle
+++ b/simplified-app-vanilla/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
   packagingOptions {
     exclude 'META-INF/LICENSE'
   }

--- a/simplified-app-vanilla/build.gradle
+++ b/simplified-app-vanilla/build.gradle
@@ -11,5 +11,5 @@ android {
 description = 'simplified-app-vanilla'
 
 dependencies {
-  compile project(':simplified-app-shared')
+  implementation project(':simplified-app-shared')
 }

--- a/simplified-assert/build.gradle
+++ b/simplified-assert/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion '27.0.3'
 }
 
 description = 'simplified-assert'

--- a/simplified-assert/build.gradle
+++ b/simplified-assert/build.gradle
@@ -7,7 +7,11 @@ android {
 
 description = 'simplified-assert'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 }

--- a/simplified-books-core/build.gradle
+++ b/simplified-books-core/build.gradle
@@ -9,20 +9,20 @@ android {
 description = 'simplified-books-core'
 
 dependencies {
-  compile project(':simplified-assert')
-  compile project(':simplified-files')
-  compile project(':simplified-http-core')
-  compile project(':simplified-downloader-core')
-  compile project(':simplified-opds-core')
+  implementation project(':simplified-assert')
+  implementation project(':simplified-files')
+  implementation project(':simplified-http-core')
+  implementation project(':simplified-downloader-core')
+  implementation project(':simplified-opds-core')
 
   implementation project(':simplified-json-core')
 
-  compile group: 'org.nypl.drm', name: 'nypl-drm-core', version: '1.0.0'
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
-  compile group: 'net.jodah', name: 'expiringmap', version: '0.4.3'
-  compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+  implementation group: 'org.nypl.drm', name: 'nypl-drm-core', version: '1.0.0'
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
+  implementation group: 'net.jodah', name: 'expiringmap', version: '0.4.3'
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
   compile project(':simplified-prefs')
   compile project(':simplified-multilibrary')
   compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"

--- a/simplified-books-core/build.gradle
+++ b/simplified-books-core/build.gradle
@@ -23,13 +23,15 @@ dependencies {
   implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
   implementation group: 'net.jodah', name: 'expiringmap', version: '0.4.3'
   implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-  compile project(':simplified-prefs')
-  compile project(':simplified-multilibrary')
-  compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+  implementation project(':simplified-prefs')
+  implementation project(':simplified-multilibrary')
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
   implementation project(':simplified-rfc3339-core')
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
 }
+
 repositories {
   mavenCentral()
+  jcenter()
 }

--- a/simplified-books-core/build.gradle
+++ b/simplified-books-core/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-books-core'
@@ -14,6 +14,9 @@ dependencies {
   compile project(':simplified-http-core')
   compile project(':simplified-downloader-core')
   compile project(':simplified-opds-core')
+
+  implementation project(':simplified-json-core')
+
   compile group: 'org.nypl.drm', name: 'nypl-drm-core', version: '1.0.0'
   compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
   compile group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
@@ -23,6 +26,9 @@ dependencies {
   compile project(':simplified-prefs')
   compile project(':simplified-multilibrary')
   compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+
+  implementation project(':simplified-rfc3339-core')
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
 }
 repositories {
   mavenCentral()

--- a/simplified-bugsnag/build.gradle
+++ b/simplified-bugsnag/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-bugsnag'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation project(':simplified-books-core')
   implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'

--- a/simplified-bugsnag/build.gradle
+++ b/simplified-bugsnag/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-bugsnag'

--- a/simplified-bugsnag/build.gradle
+++ b/simplified-bugsnag/build.gradle
@@ -8,16 +8,16 @@ android {
 description = 'simplified-bugsnag'
 
 dependencies {
-  compile project(':simplified-books-core')
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile 'com.bugsnag:bugsnag-android:3.9.0'
-  compile 'org.slf4j:slf4j-api:1.7.25'
-  compile(group: 'ch.qos.logback', name: 'logback-core', version: '1.1.3') {
+  implementation project(':simplified-books-core')
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation 'com.bugsnag:bugsnag-android:3.9.0'
+  implementation 'org.slf4j:slf4j-api:1.7.25'
+  implementation(group: 'ch.qos.logback', name: 'logback-core', version: '1.1.3') {
     /* This dependency was originally in the Maven provided scope, but the project was not of type war.
     This behavior is not yet supported by Gradle, so this dependency has been converted to a compile dependency.
     Please review and delete this closure when resolved. */
   }
-  compile(group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.3') {
+  implementation(group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.3') {
     /* This dependency was originally in the Maven provided scope, but the project was not of type war.
     This behavior is not yet supported by Gradle, so this dependency has been converted to a compile dependency.
     Please review and delete this closure when resolved. */

--- a/simplified-cardcreator/build.gradle
+++ b/simplified-cardcreator/build.gradle
@@ -18,4 +18,5 @@ dependencies {
   implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
 }

--- a/simplified-cardcreator/build.gradle
+++ b/simplified-cardcreator/build.gradle
@@ -2,17 +2,20 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-cardcreator'
 
 dependencies {
-  compile project(':simplified-books-core')
-  compile project(':simplified-http-core')
-  compile project(':simplified-json-core')
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile "com.android.support:support-v4:27.0.2"
-  compile project(':simplified-prefs')
-  compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+  implementation project(':simplified-books-core')
+  implementation project(':simplified-http-core')
+  implementation project(':simplified-json-core')
+  implementation project(':simplified-prefs')
+
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation "com.android.support:support-v4:27.0.2"
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
 }

--- a/simplified-cardcreator/build.gradle
+++ b/simplified-cardcreator/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-cardcreator'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation project(':simplified-books-core')
   implementation project(':simplified-http-core')

--- a/simplified-circ-analytics/build.gradle
+++ b/simplified-circ-analytics/build.gradle
@@ -12,4 +12,8 @@ dependencies {
   implementation project(':simplified-json-core')
   implementation project(':simplified-books-core')
   implementation project(':simplified-volley')
+  implementation project(':simplified-opds-core')
+
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 }

--- a/simplified-circ-analytics/build.gradle
+++ b/simplified-circ-analytics/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = ''
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation group: 'com.mcxiaoke.volley', name: 'library', version: '1.0.19'
   implementation project(':simplified-json-core')

--- a/simplified-circ-analytics/build.gradle
+++ b/simplified-circ-analytics/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = ''
 
 dependencies {
-  compile group: 'com.mcxiaoke.volley', name: 'library', version: '1.0.19'
-  compile project(':simplified-json-core')
-  compile project(':simplified-books-core')
-  compile project(':simplified-volley')
+  implementation group: 'com.mcxiaoke.volley', name: 'library', version: '1.0.19'
+  implementation project(':simplified-json-core')
+  implementation project(':simplified-books-core')
+  implementation project(':simplified-volley')
 }

--- a/simplified-downloader-core/build.gradle
+++ b/simplified-downloader-core/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-downloader-core'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation project(':simplified-assert')
   implementation project(':simplified-http-core')

--- a/simplified-downloader-core/build.gradle
+++ b/simplified-downloader-core/build.gradle
@@ -2,15 +2,15 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-downloader-core'
 
 dependencies {
-  compile project(':simplified-assert')
-  compile project(':simplified-http-core')
-    compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-    compile group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+  implementation project(':simplified-assert')
+  implementation project(':simplified-http-core')
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 }

--- a/simplified-files/build.gradle
+++ b/simplified-files/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-files'
 
 dependencies {
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
-  compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 }

--- a/simplified-files/build.gradle
+++ b/simplified-files/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-files'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
   implementation group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'

--- a/simplified-http-core/build.gradle
+++ b/simplified-http-core/build.gradle
@@ -2,16 +2,18 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion '27.0.3'
 }
 
 description = 'simplified-http-core'
 
 dependencies {
-  compile project(':simplified-assert')
-  compile project(':simplified-json-core')
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
-  compile group: 'net.iharder', name: 'base64', version: '2.3.9'
+  implementation project(':simplified-assert')
+  implementation project(':simplified-json-core')
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
+  implementation group: 'net.iharder', name: 'base64', version: '2.3.9'
+
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
 }

--- a/simplified-http-core/build.gradle
+++ b/simplified-http-core/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-http-core'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation project(':simplified-assert')
   implementation project(':simplified-json-core')
@@ -16,4 +20,5 @@ dependencies {
   implementation group: 'net.iharder', name: 'base64', version: '2.3.9'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 }

--- a/simplified-json-core/build.gradle
+++ b/simplified-json-core/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-json-core'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation project(':simplified-rfc3339-core')
   implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'

--- a/simplified-json-core/build.gradle
+++ b/simplified-json-core/build.gradle
@@ -2,15 +2,15 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-json-core'
 
 dependencies {
-  compile project(':simplified-rfc3339-core')
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
-  compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
+  implementation project(':simplified-rfc3339-core')
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
 }

--- a/simplified-multilibrary/build.gradle
+++ b/simplified-multilibrary/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = ''
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation project(':simplified-json-core')
   implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'

--- a/simplified-multilibrary/build.gradle
+++ b/simplified-multilibrary/build.gradle
@@ -2,13 +2,16 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = ''
 
 dependencies {
-  compile project(':simplified-json-core')
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile project(':simplified-prefs')
+  implementation project(':simplified-json-core')
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation project(':simplified-prefs')
+
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
 }

--- a/simplified-opds-core/build.gradle
+++ b/simplified-opds-core/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-opds-core'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation project(':simplified-assert')
   implementation project(':simplified-json-core')

--- a/simplified-opds-core/build.gradle
+++ b/simplified-opds-core/build.gradle
@@ -2,19 +2,19 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-opds-core'
 
 dependencies {
-  compile project(':simplified-assert')
-  compile project(':simplified-json-core')
-  compile project(':simplified-rfc3339-core')
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
-  compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.6.0-rc3'
-  compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
-  compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+  implementation project(':simplified-assert')
+  implementation project(':simplified-json-core')
+  implementation project(':simplified-rfc3339-core')
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.6.0-rc3'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 }

--- a/simplified-prefs/build.gradle
+++ b/simplified-prefs/build.gradle
@@ -7,5 +7,9 @@ android {
 
 description = ''
 
+repositories {
+  jcenter()
+}
+
 dependencies {
 }

--- a/simplified-prefs/build.gradle
+++ b/simplified-prefs/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = ''

--- a/simplified-rfc3339-core/build.gradle
+++ b/simplified-rfc3339-core/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-rfc3339-core'
 
 dependencies {
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
 }

--- a/simplified-rfc3339-core/build.gradle
+++ b/simplified-rfc3339-core/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-rfc3339-core'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
   implementation group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'

--- a/simplified-stack/build.gradle
+++ b/simplified-stack/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-stack'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
   implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'

--- a/simplified-stack/build.gradle
+++ b/simplified-stack/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-stack'
 
 dependencies {
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
-  testCompile group: 'junit', name: 'junit', version: '4.12'
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
+  testImplementation group: 'junit', name: 'junit', version: '4.12'
 }

--- a/simplified-tenprint/build.gradle
+++ b/simplified-tenprint/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-tenprint'
 
 dependencies {
-  compile group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
-  compile project(':simplified-assert')
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation project(':simplified-assert')
 }

--- a/simplified-tenprint/build.gradle
+++ b/simplified-tenprint/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-tenprint'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
   implementation project(':simplified-assert')

--- a/simplified-tests-android/build.gradle
+++ b/simplified-tests-android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 
   defaultConfig {
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -16,16 +16,16 @@ android {
 description = 'simplified-tests-android'
 
 dependencies {
-  compile project(':simplified-tests')
+  implementation project(':simplified-tests')
 
-  compile 'org.slf4j:slf4j-api:1.7.25'
-  compile 'com.github.tony19:logback-android-core:1.1.1-6'
-  compile('com.github.tony19:logback-android-classic:1.1.1-6') {
+  implementation 'org.slf4j:slf4j-api:1.7.25'
+  implementation 'com.github.tony19:logback-android-core:1.1.1-6'
+  implementation('com.github.tony19:logback-android-classic:1.1.1-6') {
     // https://github.com/tony19/logback-android/issues/73
     exclude group: 'com.google.android', module: 'android'
   }
 
-  compile 'com.android.support.test:runner:1.0.1'
+  implementation 'com.android.support.test:runner:1.0.1'
 
   androidTestImplementation 'com.android.support.test:runner:1.0.1'
   androidTestUtil 'com.android.support.test:orchestrator:1.0.1'

--- a/simplified-tests-android/build.gradle
+++ b/simplified-tests-android/build.gradle
@@ -15,6 +15,10 @@ android {
 
 description = 'simplified-tests-android'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation project(':simplified-tests')
 

--- a/simplified-tests/build.gradle
+++ b/simplified-tests/build.gradle
@@ -2,20 +2,22 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = 'simplified-tests'
 
 dependencies {
-  compile project(':simplified-books-core')
-  compile project(':simplified-files')
-  compile project(':simplified-http-core')
-  compile project(':simplified-opds-core')
-  compile project(':simplified-rfc3339-core')
+  implementation project(':simplified-books-core')
+  implementation project(':simplified-files')
+  implementation project(':simplified-http-core')
+  implementation project(':simplified-opds-core')
+  implementation project(':simplified-rfc3339-core')
 
-  compile 'junit:junit:4.12'
+  implementation 'junit:junit:4.12'
 
-  testCompile 'ch.qos.logback:logback-classic:1.2.3'
-  testCompile 'junit:junit:4.12'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
+
+  testImplementation 'ch.qos.logback:logback-classic:1.2.3'
+  testImplementation 'junit:junit:4.12'
 }

--- a/simplified-tests/build.gradle
+++ b/simplified-tests/build.gradle
@@ -13,10 +13,16 @@ dependencies {
   implementation project(':simplified-http-core')
   implementation project(':simplified-opds-core')
   implementation project(':simplified-rfc3339-core')
+  implementation project(':simplified-downloader-core')
 
   implementation 'junit:junit:4.12'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0-rc3'
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
+  implementation group: 'org.nypl.drm', name: 'nypl-drm-core', version: '1.0.0'
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+  implementation group: 'net.jodah', name: 'expiringmap', version: '0.4.3'
 
   testImplementation 'ch.qos.logback:logback-classic:1.2.3'
   testImplementation 'junit:junit:4.12'

--- a/simplified-tests/build.gradle
+++ b/simplified-tests/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = 'simplified-tests'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation project(':simplified-books-core')
   implementation project(':simplified-files')

--- a/simplified-volley/build.gradle
+++ b/simplified-volley/build.gradle
@@ -13,4 +13,6 @@ dependencies {
   implementation project(':simplified-books-core')
 
   implementation group: 'net.iharder', name: 'base64', version: '2.3.9'
+  implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
+  implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'
 }

--- a/simplified-volley/build.gradle
+++ b/simplified-volley/build.gradle
@@ -7,6 +7,10 @@ android {
 
 description = ''
 
+repositories {
+  jcenter()
+}
+
 dependencies {
   implementation group: 'com.mcxiaoke.volley', name: 'library', version: '1.0.19'
   implementation project(':simplified-json-core')

--- a/simplified-volley/build.gradle
+++ b/simplified-volley/build.gradle
@@ -2,13 +2,15 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  buildToolsVersion "27.0.3"
 }
 
 description = ''
 
 dependencies {
-  compile group: 'com.mcxiaoke.volley', name: 'library', version: '1.0.19'
-  compile project(':simplified-json-core')
-  compile project(':simplified-books-core')
+  implementation group: 'com.mcxiaoke.volley', name: 'library', version: '1.0.19'
+  implementation project(':simplified-json-core')
+  implementation project(':simplified-books-core')
+
+  implementation group: 'net.iharder', name: 'base64', version: '2.3.9'
 }


### PR DESCRIPTION
Changed build.gradle calls from "compile" to "implementation" (compile is being deprecate by google).
Updated kotlin version to 1.2.30.
