### PR TITLE
Dont search unsearchable feeds issue538

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,6 @@ helpstack.conf
 # backup files
 *~
 
-/.gitignore
+
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,4 @@ helpstack.conf
 # backup files
 *~
 
-# all Android Studio cruft
-/.idea
+

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,6 @@ helpstack.conf
 # backup files
 *~
 
+/.gitignore
+
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ ReaderClientCert.sig
 bugsnag.conf 
 helpstack.conf 
 *.jks
+
+# backup files
+*~
+
+# all Android Studio cruft
+/.idea

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogFeedActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogFeedActivity.java
@@ -688,44 +688,29 @@ public abstract class CatalogFeedActivity extends CatalogActivity implements
     return true;
   }
 
-  private void onCreateOptionsMenuSearchItem(
-    final Menu menu_nn)
-  {
+
+
+  /**
+   * If the feed actually has a search URI, then show the search field.
+   * Otherwise, disable and hide it.
+   */
+  private void onCreateOptionsMenuSearchItem(final Menu menu_nn) {
     final MenuItem search_item = menu_nn.findItem(R.id.catalog_action_search);
 
-    /**
-     * If the feed actually has a search URI, then show the search field.
-     * Otherwise, disable and hide it.
-     */
-
     final FeedType feed_actual = NullCheck.notNull(this.feed);
+
     final OptionType<FeedSearchType> search_opt = feed_actual.getFeedSearch();
+
+    // Set some placeholder text
+    final CatalogFeedArgumentsType args = this.getArguments();
+
     boolean search_ok = false;
     if (search_opt.isSome()) {
-      final Some<FeedSearchType> search_some =
-        (Some<FeedSearchType>) search_opt;
+      final Some<FeedSearchType> search_some = (Some<FeedSearchType>) search_opt;
 
       this.search_view = (SearchView) search_item.getActionView();
-      this.search_view.setSubmitButtonEnabled(true);
-      this.search_view.setIconifiedByDefault(false);
-      search_item.setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_ALWAYS);
-      search_item.expandActionView();
 
-      /**
-       * Set some placeholder text
-       */
-
-      final CatalogFeedArgumentsType args = this.getArguments();
-      this.search_view.setQueryHint("Search " + this.feed.getFeedTitle());
-      if (args.getTitle().startsWith("Search"))
-      {
-        this.search_view.setQueryHint(args.getTitle());
-      }
-
-      /**
-       * Check that the search URI is of an understood type.
-       */
-
+      // Check that the search URI is of an understood type.
       final Resources rr = NullCheck.notNull(this.getResources());
       final FeedSearchType search = search_some.get();
       search_ok = search.matchSearch(
@@ -748,13 +733,31 @@ public abstract class CatalogFeedActivity extends CatalogActivity implements
             return NullCheck.notNull(Boolean.TRUE);
           }
         });
+
+    } else {
+      CatalogFeedActivity.LOG.debug("Feed has no search opts.");
     }
 
     if (search_ok) {
+      this.search_view.setSubmitButtonEnabled(true);
+      this.search_view.setIconifiedByDefault(false);
+      search_item.setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_ALWAYS);
+      search_item.expandActionView();
+
+      this.search_view.setQueryHint("Search " + this.feed.getFeedTitle());
+      if (args.getTitle().startsWith("Search")) {
+        this.search_view.setQueryHint(args.getTitle());
+      }
+
       search_item.setEnabled(true);
       search_item.setVisible(true);
+    } else {
+      search_item.setEnabled(false);
+      search_item.collapseActionView();
+      search_item.setVisible(false);
     }
   }
+
 
   @Override protected void onDestroy()
   {

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogFeedActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogFeedActivity.java
@@ -746,7 +746,7 @@ public abstract class CatalogFeedActivity extends CatalogActivity implements
       search_item.expandActionView();
 
       // display either the category title or the previously searched keywords 
-      this.search_view.setQueryHint(String.format("%s %s", getString(R.string.search_hint_prefix), Objects.toString(this.feed.getFeedTitle(), "")));
+      this.search_view.setQueryHint(String.format(getString(R.string.search_hint_format), Objects.toString(this.feed.getFeedTitle(), getString(R.string.search_hint_feed_title_default))));
       if (args.getTitle().startsWith(getString(R.string.search_hint_prefix))) {
         this.search_view.setQueryHint(args.getTitle());
       }

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogFeedActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/catalog/CatalogFeedActivity.java
@@ -86,6 +86,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
 
@@ -744,8 +745,9 @@ public abstract class CatalogFeedActivity extends CatalogActivity implements
       search_item.setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_ALWAYS);
       search_item.expandActionView();
 
-      this.search_view.setQueryHint("Search " + this.feed.getFeedTitle());
-      if (args.getTitle().startsWith("Search")) {
+      // display either the category title or the previously searched keywords 
+      this.search_view.setQueryHint(String.format("%s %s", getString(R.string.search_hint_prefix), Objects.toString(this.feed.getFeedTitle(), "")));
+      if (args.getTitle().startsWith(getString(R.string.search_hint_prefix))) {
         this.search_view.setQueryHint(args.getTitle());
       }
 

--- a/simplified-app-shared/src/main/res/menu/catalog.xml
+++ b/simplified-app-shared/src/main/res/menu/catalog.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
 
   <item
     android:id="@+id/catalog_action_search"
@@ -8,6 +7,6 @@
     android:title="@string/catalog_search"
     android:enabled="false"
     android:visible="true"
-    app:showAsAction="always"
-    app:actionViewClass="android.widget.SearchView" />
+    android:actionViewClass="android.widget.SearchView"
+    android:showAsAction="always"/>
 </menu>

--- a/simplified-app-shared/src/main/res/menu/catalog.xml
+++ b/simplified-app-shared/src/main/res/menu/catalog.xml
@@ -6,7 +6,7 @@
     android:icon="@drawable/ic_search_black_48dp"
     android:title="@string/catalog_search"
     android:enabled="false"
-    android:visible="true"
+    android:visible="false"
     android:actionViewClass="android.widget.SearchView"
     android:showAsAction="always"/>
 </menu>

--- a/simplified-app-shared/src/main/res/menu/catalog.xml
+++ b/simplified-app-shared/src/main/res/menu/catalog.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
   <item
     android:id="@+id/catalog_action_search"
@@ -7,6 +8,6 @@
     android:title="@string/catalog_search"
     android:enabled="false"
     android:visible="true"
-    android:actionViewClass="android.widget.SearchView"
-    android:showAsAction="always"/>
+    app:showAsAction="always"
+    app:actionViewClass="android.widget.SearchView" />
 </menu>

--- a/simplified-app-shared/src/main/res/values/strings.xml
+++ b/simplified-app-shared/src/main/res/values/strings.xml
@@ -239,5 +239,6 @@
   <string name="you_are_in_new_york">We have successfully determined that you are in New York!</string>
   <string name="done_get_location">Done</string>
   <string name="next_get_location">Next</string>
+  <string name="search_hint_prefix">Search</string>
 
 </resources>

--- a/simplified-app-shared/src/main/res/values/strings.xml
+++ b/simplified-app-shared/src/main/res/values/strings.xml
@@ -58,11 +58,18 @@
   <string name="catalog_publication_date">Published</string>
   <string name="catalog_publisher">Publisher</string>
   <string name="catalog_refresh">Refresh Feed</string>
-  <string name="catalog_search">Search</string>
   <string name="catalog_unknown_feed">Unknown</string>
   <string name="catalog_more_feed">More&#8230;</string>
   <string name="catalog_requesting_loan">Requesting</string>
   <string name="catalog_requesting_revoke">Requesting</string>
+
+
+  <!-- Catalog Search-related Strings -->
+  <string name="catalog_search">Search</string>
+  <string name="search_hint_prefix">Search</string>
+  <string name="search_hint_format">Search %s</string>
+  <string name="search_hint_feed_title_default">Feed</string>
+
 
   <!-- Catalog book detail strings -->
   <string name="catalog_book_borrow">Get</string>
@@ -239,6 +246,5 @@
   <string name="you_are_in_new_york">We have successfully determined that you are in New York!</string>
   <string name="done_get_location">Done</string>
   <string name="next_get_location">Next</string>
-  <string name="search_hint_prefix">Search</string>
 
 </resources>


### PR DESCRIPTION
Search widget is no longer active or showing by default.
Now it's only displayed and activated after the catalog feed has loaded is has been found to be searchable.

This means that the customer cannot start typing a search query until the feed has finished loading, and may need to wait a noticeable time period in slow network connection conditions.  However, we felt this was a good trade-off.  The alternative was to show the search widget, load the feed, then disappear the search widget -- a frustrating experience.

Before:
![screenshot_1524088199](https://user-images.githubusercontent.com/18293410/39066534-660b13e0-44a3-11e8-9f78-c836ff4bb850.png)

After:
![screenshot_1524089648](https://user-images.githubusercontent.com/18293410/39066545-6e16bddc-44a3-11e8-8fc9-651e5ea8ac1c.png)

