### PR TITLE
Default back to NYPL ID when JSON data is missing for beta installs.

### DIFF
--- a/simplified-multilibrary/src/main/java/org/nypl/simplified/multilibrary/AccountsRegistry.java
+++ b/simplified-multilibrary/src/main/java/org/nypl/simplified/multilibrary/AccountsRegistry.java
@@ -3,6 +3,8 @@ package org.nypl.simplified.multilibrary;
 import android.content.Context;
 import android.content.res.AssetManager;
 
+import com.io7m.junreachable.UnreachableCodeException;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -11,6 +13,7 @@ import org.nypl.simplified.prefs.Prefs;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.nio.file.InvalidPathException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -173,7 +176,12 @@ public class AccountsRegistry implements Serializable {
       }
 
     }
-    return null;
+
+    try {
+      return new Account(this.getAccounts().getJSONObject(0));   //Default
+    } catch (JSONException e) {
+      throw new UnreachableCodeException(e);
+    }
   }
 
   /**


### PR DESCRIPTION
Now when a beta tester switches between versions that may or may not have a library, it always defaults to NYPL's catalog.