### PR TITLE
SimplyE Collection URL Update

### DIFF
--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/MainSettingsAccountActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/MainSettingsAccountActivity.java
@@ -599,10 +599,10 @@ public final class MainSettingsAccountActivity extends SimplifiedActivity implem
     if (Simplified.getSharedPrefs().contains("age13")) {
       in_age13_checkbox.setChecked(Simplified.getSharedPrefs().getBoolean("age13"));
     } else {
-      showAgeChoiceDialog(in_age13_checkbox);
+      showAgeGateOptionsDialog(in_age13_checkbox);
     }
 
-    in_age13_checkbox.setOnCheckedChangeListener(this::showAgeConfirmDialog);
+    in_age13_checkbox.setOnCheckedChangeListener(this::showAgeChangeConfirmation);
 
     if (this.account.needsAuth()) {
       in_login.setVisibility(View.VISIBLE);
@@ -781,7 +781,7 @@ public final class MainSettingsAccountActivity extends SimplifiedActivity implem
       WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
   }
 
-  private void showAgeChoiceDialog(CheckBox age13_box) {
+  private void showAgeGateOptionsDialog(CheckBox age13_box) {
     final AlertDialog.Builder builder = new AlertDialog.Builder(this);
 
     builder.setTitle(R.string.age_verification_title);
@@ -808,9 +808,7 @@ public final class MainSettingsAccountActivity extends SimplifiedActivity implem
     alert.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(mainTextColor);
   }
 
-  //Confirm the user wants to change their age to 'Under 13',
-  //and lose any currently downloaded books in their collection.
-  private void showAgeConfirmDialog(CompoundButton button, boolean checked) {
+  private void showAgeChangeConfirmation(CompoundButton button, boolean checked) {
     if (checked) {
       Simplified.getSharedPrefs().putBoolean("age13", true);
       setSimplyCollectionCatalog(false);

--- a/simplified-app-shared/src/main/res/values/strings.xml
+++ b/simplified-app-shared/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
   <string name="age_verification_13_younger">Under 13</string>
   <string name="age_verification_13_checkbox">I am 13 years of age or older.</string>
   <string name="age_verification_too_young">You are not old enough to sign up for a library card.</string>
+  <string name="age_verification_confirm_under13_check">Changing your age to under 13 will remove all books downloaded from the SimplyE Collection.</string>
+  <string name="age_verification_confirm_title">Delete Books?</string>
 
   <!-- Books strings -->
   <string name="books">My Books</string>

--- a/simplified-app-simplye/src/main/assets/Accounts.json
+++ b/simplified-app-simplye/src/main/assets/Accounts.json
@@ -58,8 +58,8 @@
     "supportsReservations" : false,
     "supportsHelpCenter" : false,
     "catalogUrl" : "https://circulation.librarysimplified.org/CLASSICS/",
-    "catalogUrlUnder13": "https://instantclassics.librarysimplified.org/childrens-books.xml",
-    "catalogUrl13": "https://instantclassics.librarysimplified.org/all-books.xml",
+    "catalogUrlUnder13": "http://simplye-collection-redirects.librarysimplified.org/childrens-books.xml",
+    "catalogUrl13": "http://simplye-collection-redirects.librarysimplified.org/all-books.xml",
     "licenseUrl": "http://www.librarysimplified.org/iclicenses.html",
     "mainColor": "Teal"
   },


### PR DESCRIPTION
Two new URL's for under and over 13 years of age. Needed to refactor areas of the app that handle this.

Copy and logic was updated in Settings where the checkbox resides, and the Main Catalog now looks for the setting explicitly to load the correct remote feed.

When full support comes in, the labelled part of the code should be removed (and a generic implementation applied to handle either navigation feeds or age-gated content).