### PR TITLE
Android P specific bug and crash.

### DIFF
--- a/simplified-app-simplye/src/main/AndroidManifest.xml
+++ b/simplified-app-simplye/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   package="org.nypl.simplified.simplye"
-  android:versionCode="1166"
-  android:versionName="2.2.3">
+  android:versionCode="1185"
+  android:versionName="2.2.5">
 
   <uses-sdk
     android:minSdkVersion="19"
@@ -26,7 +26,8 @@
     android:label="@string/feature_app_name"
     android:contentDescription="@string/feature_app_name"
     android:largeHeap="true"
-    android:theme="@style/SimplifiedTheme_ActionBar">
+    android:theme="@style/SimplifiedTheme_ActionBar"
+    android:usesCleartextTraffic="true">
 
     <!-- Main entry point for the application. -->
     <activity
@@ -225,6 +226,10 @@
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
     </receiver>
+
+    <uses-library
+        android:name="org.apache.http.legacy"
+        android:required="false" />
   </application>
 
 </manifest>


### PR DESCRIPTION
Clear text http support is off by default starting in Android Pie. The result is that any of our http URL's were failing. The biggest effect of this would be the two SimplyE Collection redirect URL's.

Another change starting in Pie is the requirement to add legacy support for an apache http library.
Documented [here](https://developers.google.com/maps/documentation/android-sdk/config#specify_requirement_for_apache_http_legacy_library). Some of our Volley network requests would throw an unhandled exception prior to this change.