### PR TITLE
Implement automatic returns for audio books

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,13 @@ ext {
    * The version of the NYPL Audiobook API used by this package.
    */
 
-  nypl_audiobook_api_version = "0.0.66"
+  nypl_audiobook_api_version = "0.0.67"
+
+  /*
+   * The version of the NYPL AudioEngine provider used by this package.
+   */
+
+  nypl_audiobook_findaway_version = "0.0.67"
 }
 
 allprojects {

--- a/simplified-app-shared/build.gradle
+++ b/simplified-app-shared/build.gradle
@@ -90,7 +90,7 @@ dependencies {
 
   if (project.hasProperty("org.nypl.simplified.with_findaway")) {
     if (project.property("org.nypl.simplified.with_findaway") == "true") {
-      implementation "org.nypl.audiobook:org.nypl.audiobook.android.audioengine.core:${nypl_audiobook_api_version}"
+      implementation "org.nypl.audiobook:org.nypl.audiobook.android.audioengine.core:${nypl_audiobook_findaway_version}"
     }
   }
 

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/player/AudioBookPlayerActivity.kt
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/player/AudioBookPlayerActivity.kt
@@ -437,7 +437,8 @@ class AudioBookPlayerActivity : FragmentActivity(),
 
   private fun loanReturnShowDialog() {
     val alert = AlertDialog.Builder(this)
-    alert.setTitle(R.string.audio_book_player_return)
+    alert.setTitle(R.string.audio_book_player_return_title)
+    alert.setMessage(R.string.audio_book_player_return_question)
     alert.setNegativeButton(R.string.audio_book_player_do_keep) { dialog, _ ->
       dialog.dismiss()
     }

--- a/simplified-app-shared/src/main/res/values/strings.xml
+++ b/simplified-app-shared/src/main/res/values/strings.xml
@@ -252,7 +252,8 @@
   <string name="audio_book_player">Audiobook Player</string>
   <string name="audio_book_player_error_engine_open">Unable to initialize audio engine</string>
   <string name="audio_book_player_error_book_open">Unable to open audio book</string>
-  <string name="audio_book_player_return">Return book?</string>
+  <string name="audio_book_player_return_title">Your Audiobook Has Finished</string>
+  <string name="audio_book_player_return_question">Would you like to return it?</string>
   <string name="audio_book_player_do_keep">Keep</string>
   <string name="audio_book_player_do_return">Return</string>
 

--- a/simplified-app-shared/src/main/res/values/strings.xml
+++ b/simplified-app-shared/src/main/res/values/strings.xml
@@ -252,6 +252,9 @@
   <string name="audio_book_player">Audiobook Player</string>
   <string name="audio_book_player_error_engine_open">Unable to initialize audio engine</string>
   <string name="audio_book_player_error_book_open">Unable to open audio book</string>
+  <string name="audio_book_player_return">Return book?</string>
+  <string name="audio_book_player_do_keep">Keep</string>
+  <string name="audio_book_player_do_return">Return</string>
 
   <!-- Welcome Strings -->
   <string name="welcome_library_header">Read E-Books from Your Library</string>


### PR DESCRIPTION
This change adds a dialog box that appears when the user listens to
the end of an audio book. If the user clicks the "return" button in
the dialog, the audio book loan is returned.

Fix: https://jira.nypl.org/browse/SIMPLY-391