### PR TITLE
Add extensive problem report logging

### DIFF
--- a/simplified-http-core/build.gradle
+++ b/simplified-http-core/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
   compileSdkVersion 27
@@ -14,6 +15,8 @@ repositories {
 dependencies {
   implementation project(':simplified-assert')
   implementation project(':simplified-json-core')
+
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
   implementation group: 'com.io7m.jnull', name: 'io7m-jnull-core', version: '[1.0.0, 2.0.0)'
   implementation group: 'com.io7m.junreachable', name: 'io7m-junreachable-core', version: '[1.0.0, 2.0.0)'
   implementation group: 'com.io7m.jfunctional', name: 'io7m-jfunctional-core', version: '[1.1.0, 2.0.0)'

--- a/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTPProblemReportLogging.kt
+++ b/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTPProblemReportLogging.kt
@@ -1,0 +1,68 @@
+package org.nypl.simplified.http.core
+
+import com.io7m.jfunctional.OptionType
+import com.io7m.jfunctional.Some
+import org.slf4j.Logger
+import java.net.URI
+
+/**
+ * Functions to log HTTP errors.
+ */
+
+object HTTPProblemReportLogging {
+
+  /**
+   * Log the given HTTP error.
+   *
+   * @param logger       The target logger
+   * @param uri          The original URI
+   * @param message      The error message
+   * @param statusCode   The HTTP status code
+   * @param reportOption The problem report, if one exists
+   */
+
+  fun logError(
+    logger: Logger,
+    uri: URI,
+    message: String,
+    statusCode: Int,
+    reportOption: OptionType<HTTPProblemReport>) {
+
+    val text =
+      StringBuilder(128)
+        .append("Error retrieving URI\n")
+        .append("  URI:     ")
+        .append(uri)
+        .append("\n")
+        .append("  Message: ")
+        .append(message)
+        .append("\n")
+        .append("  Status:  ")
+        .append(statusCode)
+        .append("\n")
+
+    if (reportOption.isSome) {
+      val report = (reportOption as Some<HTTPProblemReport>).get()
+      logger.error("{}",
+        text.append("  Report:\n")
+          .append("    Status: ")
+          .append(report.problemStatus)
+          .append("\n")
+          .append("    Type:   ")
+          .append(report.problemType)
+          .append("\n")
+          .append("    Title:  ")
+          .append(report.problemTitle)
+          .append("\n")
+          .append("    Detail: ")
+          .append(report.problemDetail)
+          .append("\n")
+          .toString())
+    } else {
+      logger.error("{}",
+        text.append("  Report: No problem report available\n")
+          .append("\n")
+          .toString())
+    }
+  }
+}


### PR DESCRIPTION
This logs all problem reports at ERROR level to ensure that the
contents make it into Bugsnag. This is needed in order to try to
isolate what has caused the recent spike in 400 BAD REQUEST responses.

Affects: https://jira.nypl.org/browse/SIMPLY-1648