### PR TITLE
Getting and setting the current page's CFI using Readium's JS SDK.

### DIFF
--- a/simplified-app-shared/src/main/assets/simplified.js
+++ b/simplified-app-shared/src/main/assets/simplified.js
@@ -68,6 +68,43 @@ function Simplified() {
   document.addEventListener("touchstart", handleTouchStart, false);
   document.addEventListener("touchend", handleTouchEnd, false);
 
+  /**
+   * FIXME: The following two functions are only here to provide slightly better
+   * support for returning to a particular spot in the book. This is due to the
+   * inconsistencies and the unreliability of Readium's CFI returning us to the same
+   * spot after certain UI actions take place. Previously, changing the font size (for
+   * example) constantly returned the user to the first page of the current chapter.
+   * This update is not perfect but stays within 2 to 3 pages of the current
+   * bookmark CFI captured before the UI update.
+   */
+
+  /**
+   * getReadiumCFI
+   * When there's a font size or font family change in the UI,
+   * keep track of the CFI of the current page.
+   */
+  this.getReadiumCFI = function () {
+    var currentView = ReadiumSDK.reader.getCurrentView();
+    var bookMark = currentView.bookmarkCurrentPage();
+
+    this.currentViewCFI = bookMark;
+  };
+
+  /**
+   * updateCFI
+   * If there's an existing CFI that we are tracking, open the reader to that CFI.
+   * TODO: the CFI works well for the previous font size or font family. When switching to
+   * a new font size or font family, the CFI is no longer exactly the same as before.
+   */
+  this.setReadiumCFI = function () {
+    var currentViewCFI = this.currentViewCFI || undefined;
+    if (currentViewCFI) {
+      setTimeout(function () {
+        ReadiumSDK.reader.openSpineItemElementCfi(currentViewCFI.idref, currentViewCFI.contentCFI);
+      }, 250);
+    }
+  };
+
   // This should be called by the host whenever the page changes. This is
   // because a change in the page can mean a change in the iframe and thus
   // requires resetting properties.

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
@@ -109,7 +109,6 @@ public final class ReaderActivity extends Activity implements
   private @Nullable Container                         epub_container;
   private @Nullable ReaderReadiumJavaScriptAPIType    readium_js_api;
   private @Nullable ReaderSimplifiedJavaScriptAPIType simplified_js_api;
-  private @Nullable ReaderSimplifiedJavaScriptAPIType simplified_js;
   private           ImageView                         view_bookmark;
   private @Nullable ViewGroup                         view_hud;
   private @Nullable ProgressBar                       view_loading;
@@ -433,10 +432,6 @@ public final class ReaderActivity extends Activity implements
 
     this.readium_js_api = ReaderReadiumJavaScriptAPI.newAPI(in_webview);
     this.simplified_js_api = ReaderSimplifiedJavaScriptAPI.newAPI(in_webview);
-
-    final ReaderSimplifiedJavaScriptAPIType simplified_js =
-      Objects.requireNonNull(this.simplified_js_api);
-    this.simplified_js = simplified_js;
 
     in_title_text.setText("");
 
@@ -789,13 +784,13 @@ public final class ReaderActivity extends Activity implements
 
     // Get the CFI from the ReadiumSDK before applying the new
     // page style settings.
-    this.simplified_js.getReadiumCFI();
+    this.simplified_js_api.getReadiumCFI();
 
     js.setPageStyleSettings(s);
 
     // Once they are applied, go to the CFI that is stored in the
     // JS ReadiumSDK instance.
-    this.simplified_js.setReadiumCFI();
+    this.simplified_js_api.setReadiumCFI();
 
     final ReaderColorScheme cs = s.getColorScheme();
     this.applyViewerColorScheme(cs);
@@ -1039,10 +1034,10 @@ public final class ReaderActivity extends Activity implements
         in_web_view.setVisibility(View.VISIBLE);
         in_progress_bar.setVisibility(View.VISIBLE);
         in_progress_text.setVisibility(View.VISIBLE);
-        this.simplified_js.pageHasChanged();
+        this.simplified_js_api.pageHasChanged();
       }, 200L);
     } else {
-      UIThread.runOnUIThread(this.simplified_js::pageHasChanged);
+      UIThread.runOnUIThread(this.simplified_js_api::pageHasChanged);
     }
   }
 

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderSimplifiedJavaScriptAPI.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderSimplifiedJavaScriptAPI.java
@@ -62,4 +62,14 @@ public final class ReaderSimplifiedJavaScriptAPI
   {
     this.evaluate("simplified.pageDidChange();");
   }
+
+  @Override public void getReadiumCFI()
+  {
+    this.evaluate("simplified.getReadiumCFI();");
+  }
+
+  @Override public void setReadiumCFI()
+  {
+    this.evaluate("simplified.setReadiumCFI();");
+  }
 }

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderSimplifiedJavaScriptAPIType.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderSimplifiedJavaScriptAPIType.java
@@ -7,6 +7,16 @@ package org.nypl.simplified.app.reader;
 public interface ReaderSimplifiedJavaScriptAPIType
 {
   /**
+   * Get the CFI from the JS Readium SDK.
+   */
+  void getReadiumCFI();
+
+  /**
+   * Set the CFI in the JS Readium SDK.
+   */
+  void setReadiumCFI();
+
+  /**
    * Notify the Javascript code that the page has changed in some way and
    * therefore new event listeners should be registered.
    */


### PR DESCRIPTION
This is for [JIRA ticket ](https://jira.nypl.org/browse/SIMPLY-1656). The js code here is the same as in the [Simplified-iOS](https://github.com/NYPL-Simplified/Simplified-iOS/pull/1027) PR.

Getting and setting the CFI is done in the `simplified.js` file but there's also minor changes in `ReaderActivity.java` which I'm not sure they are completely correct.
```
final ReaderSimplifiedJavaScriptAPIType simplified_js =
      Objects.requireNonNull(this.simplified_js_api);
```
The above was being called in separate functions but I wanted to use the same instance of the Simplified JS class so I added it as a class variable as `this.simplified_js`.

I had to set before and after the `js.setPageStyleSettings(s);` call. I noticed that there are java functions that call Readium's `bookmarkCurrent()` function multiple times and they receive the current CFI. But that location seems to be getting lost, specifically in `lazyInitSyncManagement` where the function throws an error (`Parameter(s) were unexpectedly null before creating Sync Manager. Abandoning attempt.`) and never goes to the `ReaderSyncManager`. This _could_ most likely be an issue with my set up.

As for the fix, this works better when decreasing the font than for increasing the font--similar to the iOS "fix".