### PR TITLE
Stop using Op.REPLACE

### DIFF
--- a/simplified-tenprint/src/main/java/org/nypl/simplified/tenprint/TenPrintGenerator.java
+++ b/simplified-tenprint/src/main/java/org/nypl/simplified/tenprint/TenPrintGenerator.java
@@ -722,7 +722,7 @@ public final class TenPrintGenerator implements TenPrintGeneratorType
         (float) margin_half,
         (float) margin_half,
         (float) (cw - margin_half),
-        (float) start_y, Op.REPLACE);
+        (float) start_y, Op.INTERSECT);
       canvas.drawRect(0.0F, 0.0F, (float) cw, (float) ch, paint_label);
     }
 


### PR DESCRIPTION
We thought we'd previously stopped doing this, but evidently we didn't
quite stop it enough.

Fix: https://jira.nypl.org/browse/SIMPLY-1710