### PR TITLE
Return Non-DRM Support in Rudimentary Form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .idea
 /captures
 /local.properties
+gradle.properties
 
 # Ignore .so files
 **/jniLibs

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The latest version of Android Studio is strongly recommended. Versions older tha
 
 ## Nexus Setup
 
-Our application currently needs packages that are only available from our Nexus server in order to build correctly. (This will be changed in the future when non-DRM-enabled variants of the app are officially supported.) Nexus credentials can be obtained by emailing `nypl@winniequinn.com` or by asking in the `#simplified-android` channel of [librarysimplified.slack.com](https://librarysimplified.slack.com).
+Our application currently needs packages that are only available from our Nexus server in order to build correctly. Nexus credentials can be obtained by emailing `leonardrichardson@nypl.org` or by asking in the `#simplified-android` channel of [librarysimplified.slack.com](https://librarysimplified.slack.com).
 
 Once you have your credentials, the following lines must be added to `~/.gradle/gradle.properties`:
 
@@ -49,16 +49,6 @@ helpstack.zendesk.staff_email = ...
 helpstack.zendesk.api_token = ...
 ```
 
-For Salesforce Desk, use the following instead:
-
-```
-helpstack.gear = desk
-helpstack.desk.instance_url = ...
-helpstack.desk.to_help_email = ...
-helpstack.desk.staff_login_email = ...
-helpstack.desk.staff_login_password =  ...
-```
-
 ## Generating Signed APKs
 
 If you wish to generate a signed APK for publishing the application, you will need to set the following values correctly in `~/.gradle/gradle.properties`:
@@ -80,6 +70,6 @@ for documentation on how to customize branding of the application.
 
 # Building
 
-**NOTE:** Due to an unknown issue, you must execute `./gradlew assembleDebug` one time before opening the project in Android Studio. This will pull in all dependencies that, for whatever reason, are not fetched if Gradle is executed via Android Studio.
+**NOTE:** Due to an unknown issue, you may need to execute `./gradlew assembleDebug` one time before opening the project in Android Studio. This will pull in all dependencies that, for whatever reason, are not fetched if Gradle is executed via Android Studio.
 
 After setup is complete, the project can be opened in Android Studio and built as normal.

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ subprojects {
 
     jcenter()
 
-    if (project.hasProperty("org.nypl.simplified.with_findaway")) {
-      if (project.property("org.nypl.simplified.with_findaway") == "true") {
+    if (project.hasProperty("org.librarysimplified.with_findaway")) {
+      if (project.property("org.librarysimplified.with_findaway") == "true") {
         maven {
           url "http://maven.findawayworld.com/artifactory/libs-release/"
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,0 @@
-org.gradle.parallel=true
-org.gradle.jvmargs=-Xms1024m -Xmx2048m
-org.nypl.simplified.with_findaway = true

--- a/simplified-app-shared/README-Implementation.md
+++ b/simplified-app-shared/README-Implementation.md
@@ -1,3 +1,9 @@
+Note
+====
+
+This document is out-of-date but may still be useful as a starting point. Please
+consult with NYPL for further assistance with branding.
+
 Implementation
 ==============
 

--- a/simplified-app-shared/build.gradle
+++ b/simplified-app-shared/build.gradle
@@ -91,8 +91,8 @@ dependencies {
   implementation "org.nypl.audiobook:org.nypl.audiobook.android.views:${nypl_audiobook_api_version}"
   implementation "org.nypl.audiobook:org.nypl.audiobook.android.downloads:${nypl_audiobook_api_version}"
 
-  if (project.hasProperty("org.nypl.simplified.with_findaway")) {
-    if (project.property("org.nypl.simplified.with_findaway") == "true") {
+  if (project.hasProperty("org.librarysimplified.with_findaway")) {
+    if (project.property("org.librarysimplified.with_findaway") == "true") {
       implementation "org.nypl.audiobook:org.nypl.audiobook.android.audioengine.core:${nypl_audiobook_findaway_version}"
     }
   }

--- a/simplified-app-simplye/build.gradle
+++ b/simplified-app-simplye/build.gradle
@@ -34,25 +34,69 @@ android {
 
 description = 'simplified-app-simplye'
 
+/*
+ * If building with Adobe DRM, check that the required certificate file exists.
+ */
+
+preBuild.doFirst {
+  def adobeDRMRequested =
+    (project.hasProperty("org.nypl.simplified.with_drm_adobe")
+        && project.property("org.nypl.simplified.with_drm_adobe") == "true")
+
+  if (adobeDRMRequested) {
+    if (!file("${project.rootDir}/simplified-app-simplye/src/main/assets/ReaderClientCert.sig").exists()) {
+      throw new IllegalStateException("""
+You are attempting to build with Adobe DRM but have not added the required
+certificate file at ${project.rootDir}/simplified-app-simplye/src/main/assets/ReaderClientCert.sig
+""")
+    }
+  } else {
+    if (file("${project.rootDir}/simplified-app-simplye/src/main/assets/ReaderClientCert.sig").exists()) {
+      throw new IllegalStateException("""
+You are attempting to build without Adobe DRM but have accidentally left the
+certificate file at ${project.rootDir}/simplified-app-simplye/src/main/assets/ReaderClientCert.sig.
+Remove this file!
+""")
+    }
+  }
+}
+
 dependencies {
   implementation project(':simplified-app-shared')
-  implementation group: 'org.nypl.drm', name: 'nypl-drm-adobe-provider', version: '1.0.0'
-  implementation group: 'org.nypl.drm', name: 'libnypl_adobe', version: '1.0.0'
-  implementation group: 'org.nypl.drm', name: 'libnypl_adobe_filter', version: '1.0.0'
+
+  /*
+   * If building with Adobe DRM, add the required native dependencies.
+   */
+
+  if (project.hasProperty("org.nypl.simplified.with_drm_adobe")) {
+    if (project.property("org.nypl.simplified.with_drm_adobe") == "true") {
+      implementation group: 'org.nypl.drm', name: 'nypl-drm-adobe-provider', version: '1.0.0'
+      implementation group: 'org.nypl.drm', name: 'libnypl_adobe', version: '1.0.0'
+      implementation group: 'org.nypl.drm', name: 'libnypl_adobe_filter', version: '1.0.0'
+    }
+  }
 
   implementation "com.android.support:support-v4:27.1.1"
 }
 
-apply plugin: 'android-native-dependencies'
+/*
+ * If building with Adobe DRM, add and process the required native dependencies.
+ */
 
-native_dependencies {
-  artifact (group: 'org.nypl.drm', name: 'libnypl_adobe', version: '1.0.0',
-      classifier: 'armeabi-v7a') {
-    addLibPrefixToArtifact=false
-  }
+if (project.hasProperty("org.nypl.simplified.with_drm_adobe")) {
+  if (project.property("org.nypl.simplified.with_drm_adobe") == "true") {
+    apply plugin: 'android-native-dependencies'
 
-  artifact (group: 'org.nypl.drm', name: 'libnypl_adobe_filter', version: '1.0.0',
-      classifier: 'armeabi-v7a') {
-    addLibPrefixToArtifact=false
+    native_dependencies {
+      artifact (group: 'org.nypl.drm', name: 'libnypl_adobe', version: '1.0.0',
+          classifier: 'armeabi-v7a') {
+        addLibPrefixToArtifact=false
+      }
+
+      artifact (group: 'org.nypl.drm', name: 'libnypl_adobe_filter', version: '1.0.0',
+          classifier: 'armeabi-v7a') {
+        addLibPrefixToArtifact=false
+      }
+    }
   }
 }

--- a/simplified-app-simplye/build.gradle
+++ b/simplified-app-simplye/build.gradle
@@ -40,8 +40,8 @@ description = 'simplified-app-simplye'
 
 preBuild.doFirst {
   def adobeDRMRequested =
-    (project.hasProperty("org.nypl.simplified.with_drm_adobe")
-        && project.property("org.nypl.simplified.with_drm_adobe") == "true")
+    (project.hasProperty("org.librarysimplified.with_drm_adobe")
+        && project.property("org.librarysimplified.with_drm_adobe") == "true")
 
   if (adobeDRMRequested) {
     if (!file("${project.rootDir}/simplified-app-simplye/src/main/assets/ReaderClientCert.sig").exists()) {
@@ -68,8 +68,8 @@ dependencies {
    * If building with Adobe DRM, add the required native dependencies.
    */
 
-  if (project.hasProperty("org.nypl.simplified.with_drm_adobe")) {
-    if (project.property("org.nypl.simplified.with_drm_adobe") == "true") {
+  if (project.hasProperty("org.librarysimplified.with_drm_adobe")) {
+    if (project.property("org.librarysimplified.with_drm_adobe") == "true") {
       implementation group: 'org.nypl.drm', name: 'nypl-drm-adobe-provider', version: '1.0.0'
       implementation group: 'org.nypl.drm', name: 'libnypl_adobe', version: '1.0.0'
       implementation group: 'org.nypl.drm', name: 'libnypl_adobe_filter', version: '1.0.0'
@@ -83,8 +83,8 @@ dependencies {
  * If building with Adobe DRM, add and process the required native dependencies.
  */
 
-if (project.hasProperty("org.nypl.simplified.with_drm_adobe")) {
-  if (project.property("org.nypl.simplified.with_drm_adobe") == "true") {
+if (project.hasProperty("org.librarysimplified.with_drm_adobe")) {
+  if (project.property("org.librarysimplified.with_drm_adobe") == "true") {
     apply plugin: 'android-native-dependencies'
 
     native_dependencies {


### PR DESCRIPTION
Our DRM systems (Findaway, Adobe) are now conditionally built with boolean flags that should be placed in `~/.gradle/gradle.properties` where other project configurations flags are set.

The absense of either or both of these flags should produce a built that still functions with non-drm collections.