### PR TITLE
Added missing catalogUrl for Open Textbooks library.

### DIFF
--- a/simplified-app-simplye/src/main/assets/Accounts.json
+++ b/simplified-app-simplye/src/main/assets/Accounts.json
@@ -2242,6 +2242,7 @@
     },
     {
         "authPasscodeLength": 0,
+        "catalogUrl": "http://open.minitex.org/textbooks/",
         "id_numeric": 1263,
         "id_uuid": "urn:uuid:5278562c-d642-4fda-ad7e-1613077cfb8d",
         "inProduction": false,


### PR DESCRIPTION
This fixes the problem I found while QAing https://jira.nypl.org/browse/SIMPLY-1920. The Open Textbooks library shows up in the list of libraries, but the catalog URL didn't make it into Accounts.json, so it's not possible to actually open the library's catalog.