### PR TITLE
Initial attempt to backport Readium improvements

### DIFF
--- a/simplified-app-shared/src/main/assets/simplified.js
+++ b/simplified-app-shared/src/main/assets/simplified.js
@@ -126,7 +126,86 @@ function Simplified() {
     // the browser to set things up in advance to achieve better performance
     // whenever the property is altered.
     contentDocument.documentElement.style["will-change"] = "left";
+
+    // Load the font family if it's not already there when the new
+    // page gets rendered.
+    this.linkOpenDyslexicFonts(contentDocument);
   };
+
+  /**
+   * TODO:
+   * Even though the OpenDyslexic3 font is now added to the renderer,
+   * there are still underlying issues with rendering this font. Specifically,
+   * pages at the end of chapters get lost when using this
+   * (and only this) font.
+   */
+
+  /**
+   * linkOpenDyslexicFonts
+   * If the current Open Dyslexic font is loaded on the page, do not
+   * load it again. If there's a currently selected font by the user,
+   * update the style to reflect it. This is needed when going from
+   * chapter to chapter.
+   */
+  this.linkOpenDyslexicFonts = function(innerDocument) {
+    var id = 'simplified-opendyslexic';
+    if (innerDocument.getElementById(id)) {
+      return;
+    }
+    var styleElement = document.createElement('style');
+    styleElement.id = id;
+    styleElement.textContent =
+      "@font-face { \
+        font-family: 'OpenDyslexic3'; \
+        src: url('OpenDyslexic3-Regular.ttf'); \
+        font-weight: normal; \
+      }";
+    innerDocument.head.appendChild(styleElement);
+
+    // If there's a user selected font, update the style.
+    var currentStyles = {};
+    if (this.currentTextColor) {
+      currentStyles["color"] = this.currentTextColor;
+    }
+    if (this.currentFont) {
+      currentStyles["font-family"] = this.currentFont;
+    }
+    if (this.currentTextColor || this.currentFont) {
+      this.updateBookStyles(currentStyles);
+    }
+  }
+
+  /**
+   * updateBookStyles
+   * If there is an existing style element in the iframe for the webreader,
+   * remove it and add an updated style element with the newly selected
+   * font family. Updating the current font selection in the object's
+   * instance as well to update the font when moving from chapter to chapter.
+   */
+  this.updateBookStyles = function(obj) {
+    var id = 'simplified-bookStyles';
+    var innerDocument = window.frames["epubContentIframe"].contentDocument;
+    if(!innerDocument) {
+      innerDocument = window.frames["epubContentIframe"].document;
+    }
+
+    var style = innerDocument.getElementById(id);
+    if (style) {
+     innerDocument.head.removeChild(style);
+    }
+    this.currentFont = obj["font-family"];
+    this.currentTextColor = obj["color"];
+
+    var styleElement = document.createElement('style');
+    styleElement.id = id;
+    styleElement.textContent =
+      "body { \
+        font-family: " + obj["font-family"] + "; \
+        color: " + obj["color"] + "; \
+      }";
+
+    innerDocument.head.appendChild(styleElement);
+  }
 
 }
 

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
@@ -760,13 +760,6 @@ public final class ReaderActivity extends ProfileTimeOutActivity implements
 
     p.setRootUrls(hs.getURIBase().toString(), null);
 
-    LOG.debug("onReadiumFunctionInitialize: scheduling font injection");
-    // is this correct? inject fonts before book opens or after
-    UIThread.runOnUIThreadDelayed(() -> {
-      LOG.debug("onReadiumFunctionInitialize: injecting fonts now");
-      this.readium_js_api.injectFonts();
-    }, 300L);
-
     /*
      * If there's a bookmark for the current book, send a request to open the
      * book to that specific page. Otherwise, start at the beginning.

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderColorSchemes.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderColorSchemes.java
@@ -26,9 +26,9 @@ public final class ReaderColorSchemes {
       case SCHEME_BLACK_ON_BEIGE:
         return Color.argb(0xff, 242, 228, 203);
       case SCHEME_BLACK_ON_WHITE:
-        return Color.WHITE;
+        return 0xff000000 | (Color.WHITE & 0xffffff);
       case SCHEME_WHITE_ON_BLACK:
-        return Color.BLACK;
+        return 0xff000000 | (Color.BLACK & 0xffffff);
     }
 
     throw new UnreachableCodeException();
@@ -40,11 +40,11 @@ public final class ReaderColorSchemes {
 
     switch (scheme) {
       case SCHEME_BLACK_ON_BEIGE:
-        return Color.BLACK;
+        return 0xff000000 | (Color.BLACK & 0xffffff);
       case SCHEME_BLACK_ON_WHITE:
-        return Color.BLACK;
+        return 0xff000000 | (Color.BLACK & 0xffffff);
       case SCHEME_WHITE_ON_BLACK:
-        return Color.WHITE;
+        return 0xff000000 | (Color.WHITE & 0xffffff);
     }
 
     throw new UnreachableCodeException();

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderReadiumJavaScriptAPI.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderReadiumJavaScriptAPI.java
@@ -21,8 +21,6 @@ import org.nypl.simplified.reader.api.ReaderPreferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.nypl.simplified.app.reader.ReaderReadiumViewerSettings.SyntheticSpreadMode.SINGLE;
-
 /**
  * The default implementation of the {@link ReaderReadiumJavaScriptAPIType}
  * interface.
@@ -159,36 +157,34 @@ public final class ReaderReadiumJavaScriptAPI implements ReaderReadiumJavaScript
     final ReaderPreferences preferences) {
     try {
       final ReaderColorScheme cs = preferences.colorScheme();
-      final String color =
-        NullCheck.notNull(String.format("#%06x", ReaderColorSchemes.foreground(cs)));
-      final String background =
-        NullCheck.notNull(String.format("#%06x", ReaderColorSchemes.background(cs)));
+
+      final String color = NullCheck.notNull(
+        String.format("#%06x", ReaderColorSchemes.foreground(cs)));
+      final String background = NullCheck.notNull(
+        String.format("#%06x", ReaderColorSchemes.background(cs)));
 
       final JSONObject decls = new JSONObject();
       decls.put("color", color);
       decls.put("backgroundColor", background);
+      String fontSelected = "";
 
       switch (preferences.fontFamily()) {
         case READER_FONT_SANS_SERIF: {
           decls.put("font-family", "sans-serif");
+          fontSelected = "sans-serif";
           break;
         }
         case READER_FONT_OPEN_DYSLEXIC: {
-          /*
-           * This is defined as a custom CSS font family inside
-           * OpenDyslexic.css, which is referenced from the initially
-           * loaded reader.html file.
-           */
-
           decls.put("font-family", "OpenDyslexic3");
+          fontSelected = "OpenDyslexic3";
           break;
         }
         case READER_FONT_SERIF: {
           decls.put("font-family", "serif");
+          fontSelected = "serif";
           break;
         }
       }
-
       final JSONObject o = new JSONObject();
       o.put("selector", "*");
       o.put("declarations", decls);
@@ -205,40 +201,23 @@ public final class ReaderReadiumJavaScriptAPI implements ReaderReadiumJavaScript
       script.append("\";");
       this.evaluate(script.toString());
 
-      final ReaderReadiumViewerSettings vs =
-        new ReaderReadiumViewerSettings(
-          SINGLE, ScrollMode.AUTO, (int) preferences.fontScale(), 20);
+      final ReaderReadiumViewerSettings vs = new ReaderReadiumViewerSettings(
+        ReaderReadiumViewerSettings.SyntheticSpreadMode.SINGLE,
+        ScrollMode.AUTO,
+        (int) preferences.fontScale(),
+        20);
 
       this.evaluate(
         NullCheck.notNull(
           String.format("ReadiumSDK.reader.updateSettings(%s);", vs.toJSON())));
 
+      // Update the selected user font through the custom Simplified JS script.
+      this.evaluate(
+        NullCheck.notNull(
+          String.format("simplified.updateBookStyles({ 'font-family': '%1s', color: '%2s'});", fontSelected, color)));
     } catch (final JSONException e) {
-      LOG.error(
+      ReaderReadiumJavaScriptAPI.LOG.error(
         "error constructing json: {}", e.getMessage(), e);
-    }
-  }
-
-  @Override
-  public void injectFonts() {
-    try {
-      final JSONObject s = new JSONObject();
-      s.put("truetype", "OpenDyslexic3-Regular.ttf");
-
-      final JSONObject o = new JSONObject();
-      o.put("fontFamily", "OpenDyslexic3");
-      o.put("fontWeight", "normal");
-      o.put("fontStyle", "normal");
-      o.put("sources", s);
-
-      final StringBuilder script = new StringBuilder(256);
-      script.append("ReadiumSDK.reader.plugins.injectFonts.registerFontFace(");
-      script.append(o);
-      script.append(");");
-
-      this.evaluate(script.toString());
-    } catch (final JSONException e) {
-      LOG.error("error constructing json: {}", e.getMessage(), e);
     }
   }
 

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderReadiumJavaScriptAPIType.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderReadiumJavaScriptAPIType.java
@@ -90,11 +90,4 @@ public interface ReaderReadiumJavaScriptAPIType
 
   void setPageStyleSettings(
     ReaderPreferences r);
-
-  /**
-   * Inject any configurable fonts into the web view. This should be called
-   * once, prior to opening a book.
-   */
-
-  void injectFonts();
 }

--- a/simplified-app-simplye/version.properties
+++ b/simplified-app-simplye/version.properties
@@ -1,4 +1,4 @@
 #
-#Wed Jul 24 09:26:54 UTC 2019
+#Wed Jul 24 10:45:07 UTC 2019
 versionName=3.0.14
-versionCode=3203
+versionCode=3208


### PR DESCRIPTION
This attempts to port @EdwinGuzman 's old Readium improvements to
the current development branch. This seems to be working in that
OpenDyslexic is now usable again, and all color schemes appear to work
correctly. Some books still have a problem with the white-text-on-black
color scheme, but this appears to be a book-specific issue and may
not be fixable (I believe some books include CSS that can't be
overridden without specific knowledge of the book's stylesheets).

References: https://github.com/NYPL-Simplified/android/commit/57f661f976119d8dfc2e6071084f0945c7ba3c79
Affects: http://jira.nypl.org/browse/SIMPLY-1933