### PR TITLE
Adds in the `PdfReaderActivity` to the manifest of the vanilla build.

### DIFF
--- a/simplified-app-vanilla-with-profiles/version.properties
+++ b/simplified-app-vanilla-with-profiles/version.properties
@@ -1,4 +1,4 @@
 #
-#Thu Sep 12 18:59:23 UTC 2019
+#Fri Sep 13 09:09:39 CDT 2019
 versionName=3.0.14
-versionCode=4118
+versionCode=4120

--- a/simplified-app-vanilla/src/main/AndroidManifest.xml
+++ b/simplified-app-vanilla/src/main/AndroidManifest.xml
@@ -141,6 +141,14 @@
       android:exported="false"
       android:label="@string/audio_book_player" />
 
+    <!-- PDF Reader -->
+    <activity
+        android:name="org.nypl.simplified.app.pdf.PdfReaderActivity"
+        android:configChanges="orientation|screenSize"
+        android:contentDescription="@string/reader"
+        android:exported="true"
+        android:label="@string/reader" />
+
     <activity
       android:name="org.nypl.simplified.app.ReportIssueActivity"
       android:contentDescription="@string/hs_issuebutton_title"

--- a/simplified-app-vanilla/version.properties
+++ b/simplified-app-vanilla/version.properties
@@ -1,4 +1,4 @@
 #
-#Thu Sep 12 18:59:22 UTC 2019
+#Fri Sep 13 09:09:39 CDT 2019
 versionName=3.0.14
-versionCode=4121
+versionCode=4123


### PR DESCRIPTION
Adds a reference to `PdfReaderActivity` to the vanilla flavor's `AndroidManifest.xml`. This fixes the issue where attempting to open a PDF crashes in the app.