### PR TITLE
Bump ktlint version to 0.36.0; move ktlint tasks to "quality" group.

### DIFF
--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -5,15 +5,15 @@ configurations {
     ktlint
 }
 dependencies {
-    ktlint "com.pinterest:ktlint:0.34.2"
+    ktlint "com.pinterest:ktlint:0.36.0"
 }
-task ktlint(type: JavaExec, group: "verification") {
+task ktlint(type: JavaExec, group: "quality") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
     main = "com.pinterest.ktlint.Main"
     args "src/**/*.kt"
 }
-task ktlintFormat(type: JavaExec, group: "formatting") {
+task ktlintFormat(type: JavaExec, group: "quality") {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
     main = "com.pinterest.ktlint.Main"


### PR DESCRIPTION
Just a quick little change I made as I was poking around the project.

I moved the ktlint tasks to a new "quality" group. This is something I've done on other projects and is kinda nice because they're easier to spot when you run `./gradlew tasks`.

Happy to revert the group change and just do a version bump if y'all prefer it as-is.