### PR TITLE
Bump nexus-staging plugin to version 0.21.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     classpath "com.nabilhachicha:android-native-dependencies:0.1.2"
     classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.15.0"
     classpath "digital.wup:android-maven-publish:3.6.3"
-    classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.1"
+    classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.android.tools.build:gradle:3.5.3'
   }
@@ -26,7 +26,7 @@ plugins {
   id "com.github.ben-manes.versions" version "0.27.0"
   id "com.vanniktech.android.junit.jacoco" version "0.15.0"
   id "digital.wup.android-maven-publish" version "3.6.3"
-  id "io.codearte.nexus-staging" version "0.21.1"
+  id "io.codearte.nexus-staging" version "0.21.2"
   id "ru.vyarus.animalsniffer" version "1.5.0"
 }
 


### PR DESCRIPTION
This fixes a StackOverflowError in some cases when building on Gradle 6.
https://github.com/Codearte/gradle-nexus-staging-plugin/pull/142

I was seeing a StackOverflowError when executing `./gradlew properties` on the root project. Rerunning the command with `./gradlew properties --stacktrace` indicated the nexus staging plugin was the culprit.