### PR TITLE
Remove redundant summary text from entries in app settings.

### DIFF
--- a/simplified-ui-settings/src/main/res/values/strings.xml
+++ b/simplified-ui-settings/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 <resources>
   <string name="settings">Settings</string>
   <string name="settingsAbout">About</string>
-  <string name="settingsAboutSummary">Information about this application…</string>
+  <string name="settingsAboutSummary" />
   <string name="settingsAccountAdd">Add account…</string>
   <string name="settingsAccountCreationFailed">Account creation failed</string>
   <string name="settingsAccountCreationFailedMessage">The account \'%1$s\' could not be created.</string>
@@ -20,9 +20,9 @@
   <string name="settingsAccountRegistryRetrieving">Retrieving accounts from registry…</string>
   <string name="settingsAccountRegistrySelect">Please select a library…</string>
   <string name="settingsAccounts">Accounts</string>
-  <string name="settingsAccountsSummary">Add, remove, and configure accounts…</string>
+  <string name="settingsAccountsSummary">Add, remove, or configure accounts</string>
   <string name="settingsAcknowledgements">Acknowledgements</string>
-  <string name="settingsAcknowledgementsSummary">Acknowledgements and development credits…</string>
+  <string name="settingsAcknowledgementsSummary" />
   <string name="settingsCancel">Cancel</string>
   <string name="settingsCardCreatorLabel">Don\'t have a library card?</string>
   <string name="settingsCardCreatorSignUp">Sign up</string>
@@ -36,14 +36,14 @@
   <string name="settingsDelete">Delete</string>
   <string name="settingsDetails">Details</string>
   <string name="settingsDocumentation">Documentation</string>
-  <string name="settingsEULA">User Agreement</string>
+  <string name="settingsEULA">User agreement</string>
   <string name="settingsEULAStatement">I agree to the terms of the End User License Agreement.</string>
-  <string name="settingsEULASummary">User agreement information…</string>
+  <string name="settingsEULASummary" />
   <string name="settingsFaq">FAQ</string>
-  <string name="settingsFaqSummary">Frequently asked questions…</string>
+  <string name="settingsFaqSummary" />
   <string name="settingsInfo">Information</string>
   <string name="settingsLicense">License</string>
-  <string name="settingsLicenseSummary">Software license information…</string>
+  <string name="settingsLicenseSummary">Software license information</string>
   <string name="settingsLogin">Log in</string>
   <string name="settingsLogout">Log out</string>
   <string name="settingsPassword">Password</string>
@@ -53,9 +53,9 @@
   <string name="settingsReportIssue">Report an issue…</string>
   <string name="settingsSyncBookmarks">Sync bookmarks</string>
   <string name="settingsUserName">User Name</string>
-  <string name="settingsVersion">Version</string>
+  <string name="settingsVersion">App version</string>
   <string name="settingsVersionBuild">Build</string>
   <string name="settingsVersionDeveloper">Developer Options</string>
-  <string name="settingsVersionSummary">Application version information…</string>
+  <string name="settingsVersionSummary" />
   <string name="settingsVersionVersion">Version</string>
 </resources>

--- a/simplified-ui-settings/src/main/res/xml/settings.xml
+++ b/simplified-ui-settings/src/main/res/xml/settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <Preference
     android:key="settingsAccounts"
@@ -38,7 +39,8 @@
     <Preference
       android:key="settingsVersion"
       android:title="@string/settingsVersion"
-      android:summary="@string/settingsVersionSummary" />
+      android:summary="@string/settingsVersionSummary"
+      tools:summary="4.3.1 (5001)" />
   </PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Small copy change to remove some extraneous information from the settings page.

This is just a suggestion that improves the readability a bit. For copy changes like this, do we need to go through an approval process?

- [Screenshot: Before](https://user-images.githubusercontent.com/107117/71929967-9af2c400-314f-11ea-93a1-1f4ad724bc14.png)
- [Screenshot: After](https://user-images.githubusercontent.com/107117/71929992-a5ad5900-314f-11ea-8c80-5c184c5fee97.png)
