### PR TITLE
SMA-251: Ensure 7.0.2 build has no dark theme artifacts

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -108,7 +108,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
   private lateinit var authenticationViews: AccountAuthenticationViews
   private lateinit var bookmarkSync: ViewGroup
   private lateinit var bookmarkSyncCheck: SwitchCompat
-  private lateinit var bookmarkSyncLabel: View
   private lateinit var bookmarkSyncProgress: ProgressBar
   private lateinit var loginButtonErrorDetails: Button
   private lateinit var loginProgress: ViewGroup
@@ -170,8 +169,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       view.findViewById(R.id.accountSyncBookmarks)
     this.bookmarkSyncCheck =
       this.bookmarkSync.findViewById(R.id.accountSyncBookmarksCheck)
-    this.bookmarkSyncLabel =
-      this.bookmarkSync.findViewById(R.id.accountSyncBookmarksLabel)
 
     this.loginTitle =
       view.findViewById(R.id.accountTitleAnnounce)
@@ -265,7 +262,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
 
             this.bookmarkSyncCheck.isChecked = isPermitted
             this.bookmarkSyncCheck.isEnabled = isSupported
-            this.bookmarkSyncLabel.isEnabled = isSupported
 
             this.bookmarkSyncCheck.setOnCheckedChangeListener { _, isChecked ->
               this.viewModel.enableBookmarkSyncing(isChecked)

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -37,7 +37,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginBottom="1dp"
-        android:background="?android:attr/listDivider"
+        android:background="@color/simplifiedColorDisabledAccessibility"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
@@ -49,7 +49,7 @@
     <View
       android:layout_width="match_parent"
       android:layout_height="1dp"
-      android:background="?android:attr/listDivider" />
+      android:background="@color/simplifiedColorDisabledAccessibility" />
 
     <Space
       android:layout_width="match_parent"
@@ -154,7 +154,7 @@
       <View
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:background="?android:attr/listDivider"
+        android:background="@color/simplifiedColorDisabledAccessibility"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -197,7 +197,7 @@
       <View
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:background="?android:attr/listDivider"
+        android:background="@color/simplifiedColorDisabledAccessibility"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -210,7 +210,6 @@
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:enabled="false"
         android:labelFor="@id/accountSyncBookmarksCheck"
         android:text="@string/accountSyncBookmarks"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -255,7 +254,7 @@
       <View
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:background="?android:attr/listDivider"
+        android:background="@color/simplifiedColorDisabledAccessibility"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -299,7 +298,7 @@
       <View
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:background="?android:attr/listDivider"
+        android:background="@color/simplifiedColorDisabledAccessibility"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/simplified-ui-theme/src/main/res/drawable/simplified_button.xml
+++ b/simplified-ui-theme/src/main/res/drawable/simplified_button.xml
@@ -12,7 +12,7 @@
       <solid android:color="?attr/simplifiedColorBackground" />
       <stroke
         android:width="1dp"
-        android:color="?attr/simplifiedColorDisabled" />
+        android:color="@color/simplifiedColorDisabledAccessibility" />
     </shape>
   </item>
 

--- a/simplified-ui-theme/src/main/res/values/styles.xml
+++ b/simplified-ui-theme/src/main/res/values/styles.xml
@@ -5,6 +5,7 @@
   <color name="simplifiedColorPrimary">#0d47a1</color>
   <color name="simplifiedColorPrimaryDark">#002171</color>
   <color name="simplifiedColorDisabled">#dddddd</color>
+  <color name="simplifiedColorDisabledAccessibility">#D3D3D3</color>
   <color name="simplifiedColorBackground">#ffffff</color>
   <dimen name="simplifiedButtonCornerRadius">6dp</dimen>
   <dimen name="simplifiedButtonVerticalPadding">8dp</dimen>


### PR DESCRIPTION
**What's this do?**
1. Removes the enabling/disabling on the account sync label
2. Change the default disable color for line seperators

**Why are we doing this? (w/ JIRA link if applicable)**
[SMA-251: Ensure 7.0.2 build has no dark theme artifacts](https://jira.nypl.org/browse/SMA-251)

**How should this be tested? / Do these changes have associated tests?**
Launch the accounts screen and examine the color updates

**Dependencies for merging? Releasing to production?**
This is a blocker for the 7.0.2 release

**Have you updated the changelog?**
In progress

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
