### PR TITLE
OE-217: Restore return button in Open eBooks

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -235,6 +235,11 @@
             <c:ticket id="SMA-210"/>
           </c:tickets>
         </c:change>
+        <c:change date="2021-10-18T08:26:45+00:00" summary="Restore return button in Open eBooks">
+          <c:tickets>
+            <c:ticket id="OE-217"/>
+          </c:tickets>
+        </c:change>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
+++ b/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
@@ -42,6 +42,6 @@ class OEIBuildConfigurationService : BuildConfigurationServiceType {
     get() = false
 
   override fun allowReturns(): Boolean {
-    return false
+    return true
   }
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -108,7 +108,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
   private lateinit var authenticationViews: AccountAuthenticationViews
   private lateinit var bookmarkSync: ViewGroup
   private lateinit var bookmarkSyncCheck: SwitchCompat
-  private lateinit var bookmarkSyncLabel: View
   private lateinit var bookmarkSyncProgress: ProgressBar
   private lateinit var loginButtonErrorDetails: Button
   private lateinit var loginProgress: ViewGroup
@@ -170,8 +169,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       view.findViewById(R.id.accountSyncBookmarks)
     this.bookmarkSyncCheck =
       this.bookmarkSync.findViewById(R.id.accountSyncBookmarksCheck)
-    this.bookmarkSyncLabel =
-      this.bookmarkSync.findViewById(R.id.accountSyncBookmarksLabel)
 
     this.loginTitle =
       view.findViewById(R.id.accountTitleAnnounce)
@@ -265,7 +262,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
 
             this.bookmarkSyncCheck.isChecked = isPermitted
             this.bookmarkSyncCheck.isEnabled = isSupported
-            this.bookmarkSyncLabel.isEnabled = isSupported
 
             this.bookmarkSyncCheck.setOnCheckedChangeListener { _, isChecked ->
               this.viewModel.enableBookmarkSyncing(isChecked)

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -37,7 +37,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginBottom="1dp"
-        android:background="?android:attr/listDivider"
+        android:background="@color/accessibility_grey"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
@@ -49,7 +49,7 @@
     <View
       android:layout_width="match_parent"
       android:layout_height="1dp"
-      android:background="?android:attr/listDivider" />
+      android:background="@color/accessibility_grey" />
 
     <Space
       android:layout_width="match_parent"
@@ -154,7 +154,7 @@
       <View
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:background="?android:attr/listDivider"
+        android:background="@color/accessibility_grey"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -197,7 +197,7 @@
       <View
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:background="?android:attr/listDivider"
+        android:background="@color/accessibility_grey"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -210,7 +210,6 @@
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:enabled="false"
         android:labelFor="@id/accountSyncBookmarksCheck"
         android:text="@string/accountSyncBookmarks"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -255,7 +254,7 @@
       <View
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:background="?android:attr/listDivider"
+        android:background="@color/accessibility_grey"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -299,7 +298,7 @@
       <View
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:background="?android:attr/listDivider"
+        android:background="@color/accessibility_grey"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/simplified-ui-theme/src/main/res/color-night/simplified_button_stroke.xml
+++ b/simplified-ui-theme/src/main/res/color-night/simplified_button_stroke.xml
@@ -6,7 +6,7 @@
 
   <item
     android:state_enabled="false"
-    android:color="?attr/simplifiedColorDisabled" />
+    android:color="?attr/simplifiedColorDisabledAccessibility" />
 
   <item
     android:state_pressed="true"

--- a/simplified-ui-theme/src/main/res/color-night/simplified_button_text.xml
+++ b/simplified-ui-theme/src/main/res/color-night/simplified_button_text.xml
@@ -6,7 +6,7 @@
 
   <item
     android:state_enabled="false"
-    android:color="?attr/simplifiedColorDisabled" />
+    android:color="?attr/simplifiedColorDisabledAccessibility" />
 
   <item
     android:state_pressed="true"

--- a/simplified-ui-theme/src/main/res/color-notnight/simplified_button_stroke.xml
+++ b/simplified-ui-theme/src/main/res/color-notnight/simplified_button_stroke.xml
@@ -6,7 +6,7 @@
 
   <item
     android:state_enabled="false"
-    android:color="?attr/simplifiedColorDisabled" />
+    android:color="?attr/simplifiedColorDisabledAccessibility" />
 
   <item
     android:state_pressed="true"

--- a/simplified-ui-theme/src/main/res/color-notnight/simplified_button_text.xml
+++ b/simplified-ui-theme/src/main/res/color-notnight/simplified_button_text.xml
@@ -6,7 +6,7 @@
 
   <item
     android:state_enabled="false"
-    android:color="?attr/simplifiedColorDisabled" />
+    android:color="?attr/simplifiedColorDisabledAccessibility" />
 
   <item
     android:state_pressed="true"

--- a/simplified-ui-theme/src/main/res/values-night/themes.xml
+++ b/simplified-ui-theme/src/main/res/values-night/themes.xml
@@ -13,7 +13,6 @@
     <item name="simplifiedColorBackground">@color/almost_black</item>
     <item name="simplifiedColorItemBackground">@color/lighter_black</item>
     <item name="simplifiedColorItemStroke">@color/morado_gray</item>
-    <item name="simplifiedColorDisabled">@color/santas_gray</item>
     <item name="simplifiedColorDisabledAccessibility">@color/accessibility_grey</item>
 
     <item name="simplifiedColorNavigationSelected">?attr/simplifiedColorText</item>"
@@ -41,7 +40,6 @@
     <item name="simplifiedColorBackground">@color/almost_black</item>
     <item name="simplifiedColorItemBackground">@color/lighter_black</item>
     <item name="simplifiedColorItemStroke">@color/morado_gray</item>
-    <item name="simplifiedColorDisabled">@color/santas_gray</item>
     <item name="simplifiedColorDisabledAccessibility">@color/accessibility_grey</item>
 
     <item name="simplifiedColorNavigationSelected">?attr/simplifiedColorText</item>"

--- a/simplified-ui-theme/src/main/res/values-night/themes.xml
+++ b/simplified-ui-theme/src/main/res/values-night/themes.xml
@@ -14,6 +14,7 @@
     <item name="simplifiedColorItemBackground">@color/lighter_black</item>
     <item name="simplifiedColorItemStroke">@color/morado_gray</item>
     <item name="simplifiedColorDisabled">@color/santas_gray</item>
+    <item name="simplifiedColorDisabledAccessibility">@color/accessibility_grey</item>
 
     <item name="simplifiedColorNavigationSelected">?attr/simplifiedColorText</item>"
     <item name="simplifiedColorNavigationUnselected">@color/white</item>"
@@ -41,6 +42,7 @@
     <item name="simplifiedColorItemBackground">@color/lighter_black</item>
     <item name="simplifiedColorItemStroke">@color/morado_gray</item>
     <item name="simplifiedColorDisabled">@color/santas_gray</item>
+    <item name="simplifiedColorDisabledAccessibility">@color/accessibility_grey</item>
 
     <item name="simplifiedColorNavigationSelected">?attr/simplifiedColorText</item>"
     <item name="simplifiedColorNavigationUnselected">@color/white</item>"

--- a/simplified-ui-theme/src/main/res/values-notnight/themes.xml
+++ b/simplified-ui-theme/src/main/res/values-notnight/themes.xml
@@ -14,6 +14,7 @@
     <item name="simplifiedColorItemBackground">@color/white</item>
     <item name="simplifiedColorItemStroke">@color/yet_another_gray</item>
     <item name="simplifiedColorDisabled">@color/platinum</item>
+    <item name="simplifiedColorDisabledAccessibility">@color/accessibility_grey</item>
 
     <item name="simplifiedColorNavigationSelected">?attr/simplifiedColorPrimary</item>
     <item name="simplifiedColorNavigationUnselected">@color/dkgray</item>
@@ -41,6 +42,7 @@
     <item name="simplifiedColorItemBackground">@color/white</item>
     <item name="simplifiedColorItemStroke">@color/yet_another_gray</item>
     <item name="simplifiedColorDisabled">@color/platinum</item>
+    <item name="simplifiedColorDisabledAccessibility">@color/accessibility_grey</item>
 
     <item name="simplifiedColorNavigationSelected">?attr/simplifiedColorPrimary</item>
     <item name="simplifiedColorNavigationUnselected">@color/dkgray</item>

--- a/simplified-ui-theme/src/main/res/values-notnight/themes.xml
+++ b/simplified-ui-theme/src/main/res/values-notnight/themes.xml
@@ -13,7 +13,6 @@
     <item name="simplifiedColorBackground">@color/white</item>
     <item name="simplifiedColorItemBackground">@color/white</item>
     <item name="simplifiedColorItemStroke">@color/yet_another_gray</item>
-    <item name="simplifiedColorDisabled">@color/platinum</item>
     <item name="simplifiedColorDisabledAccessibility">@color/accessibility_grey</item>
 
     <item name="simplifiedColorNavigationSelected">?attr/simplifiedColorPrimary</item>
@@ -41,7 +40,6 @@
     <item name="simplifiedColorBackground">@color/white</item>
     <item name="simplifiedColorItemBackground">@color/white</item>
     <item name="simplifiedColorItemStroke">@color/yet_another_gray</item>
-    <item name="simplifiedColorDisabled">@color/platinum</item>
     <item name="simplifiedColorDisabledAccessibility">@color/accessibility_grey</item>
 
     <item name="simplifiedColorNavigationSelected">?attr/simplifiedColorPrimary</item>

--- a/simplified-ui-theme/src/main/res/values/palette.xml
+++ b/simplified-ui-theme/src/main/res/values/palette.xml
@@ -6,6 +6,7 @@
   <color name="platinum_gray">#797979</color>
   <color name="santas_gray">#9999A1</color>
   <color name="platinum">#dddddd</color>
+  <color name="accessibility_grey">D3D3D3</color>
   <color name="yet_another_gray">#EEEEEF</color>
   <color name="morado_gray">#8d8d93</color>
   <color name="lighter_gray">#616161</color>

--- a/simplified-ui-theme/src/main/res/values/palette.xml
+++ b/simplified-ui-theme/src/main/res/values/palette.xml
@@ -6,7 +6,7 @@
   <color name="platinum_gray">#797979</color>
   <color name="santas_gray">#9999A1</color>
   <color name="platinum">#dddddd</color>
-  <color name="accessibility_grey">D3D3D3</color>
+  <color name="accessibility_grey">#D3D3D3</color>
   <color name="yet_another_gray">#EEEEEF</color>
   <color name="morado_gray">#8d8d93</color>
   <color name="lighter_gray">#616161</color>

--- a/simplified-ui-theme/src/main/res/values/themes.xml
+++ b/simplified-ui-theme/src/main/res/values/themes.xml
@@ -13,6 +13,7 @@
     <attr name="simplifiedColorItemBackground" format="color" />
     <attr name="simplifiedColorItemStroke" format="color" />
     <attr name="simplifiedColorDisabled" format="color" />
+    <attr name="simplifiedColorDisabledAccessibility" format="color"/>
     <attr name="simplifiedColorText" format="color" />
     <attr name="simplifiedColorPreferenceCategory" format="color" />
     <attr name="simplifiedColorControlActionBar" format="color" />

--- a/simplified-ui-theme/src/main/res/values/themes.xml
+++ b/simplified-ui-theme/src/main/res/values/themes.xml
@@ -12,7 +12,6 @@
     <attr name="simplifiedColorBackground" format="color" />
     <attr name="simplifiedColorItemBackground" format="color" />
     <attr name="simplifiedColorItemStroke" format="color" />
-    <attr name="simplifiedColorDisabled" format="color" />
     <attr name="simplifiedColorDisabledAccessibility" format="color"/>
     <attr name="simplifiedColorText" format="color" />
     <attr name="simplifiedColorPreferenceCategory" format="color" />


### PR DESCRIPTION
**What's this do?**
Here I have enabled the return button for Open eBooks. I've also added a new disable color for accessibility purposes. This has been done again to fit into the dark mode work that @qnga did/.

**Why are we doing this? (w/ JIRA link if applicable)**
[OE-217: Restore return button in Open eBooks](https://jira.nypl.org/browse/OE-217)

**How should this be tested? / Do these changes have associated tests?**
Launch Open eBooks and examine the return button is now available.

**Dependencies for merging? Releasing to production?**
Please disregard the commit message, I accidentally referred to a PR that disabled the return button. Will do a merge commit and that won't be seen in the git history.

**Have you updated the changelog?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
<img src="https://user-images.githubusercontent.com/15109016/137774985-3888efa8-8608-47ae-a3a2-0b6b36512c70.png" data-canonical-src="https://user-images.githubusercontent.com/15109016/137774985-3888efa8-8608-47ae-a3a2-0b6b36512c70.png" width="300" /><img src="https://user-images.githubusercontent.com/15109016/137775542-0864074a-568b-4754-9d06-cc4ce0a37754.png" data-canonical-src="https://user-images.githubusercontent.com/15109016/137775542-0864074a-568b-4754-9d06-cc4ce0a37754.png" width="300" />
