### PR TITLE
SMA-280: Jr card creation screens appear difficult to read with dark mode on

### DIFF
--- a/simplified-app-openebooks/src/main/AndroidManifest.xml
+++ b/simplified-app-openebooks/src/main/AndroidManifest.xml
@@ -84,7 +84,8 @@
             android:name="org.nypl.simplified.cardcreator.CardCreatorActivity"
             android:contentDescription="@string/appName"
             android:exported="false"
-            android:label="@string/appName" />
+            android:label="@string/appName"
+            android:theme="@style/OEI_NoActionBar" />
 
     </application>
 </manifest>

--- a/simplified-app-simplye/src/main/AndroidManifest.xml
+++ b/simplified-app-simplye/src/main/AndroidManifest.xml
@@ -80,7 +80,7 @@
         android:contentDescription="@string/appName"
         android:exported="false"
         android:label="@string/appName"
-        android:theme="@style/SimplyE_ActionBar"/>
+        android:theme="@style/SimplyE_NoActionBar"/>
 
   </application>
 

--- a/simplified-app-simplye/src/main/AndroidManifest.xml
+++ b/simplified-app-simplye/src/main/AndroidManifest.xml
@@ -79,7 +79,8 @@
         android:name="org.nypl.simplified.cardcreator.CardCreatorActivity"
         android:contentDescription="@string/appName"
         android:exported="false"
-        android:label="@string/appName" />
+        android:label="@string/appName"
+        android:theme="@style/SimplyE_ActionBar"/>
 
   </application>
 

--- a/simplified-app-vanilla/src/main/AndroidManifest.xml
+++ b/simplified-app-vanilla/src/main/AndroidManifest.xml
@@ -77,6 +77,7 @@
     <activity
       android:name="org.nypl.simplified.cardcreator.CardCreatorActivity"
       android:exported="false"
+      android:theme="@style/VanillaTheme_NoActionBar"
       android:windowSoftInputMode="adjustResize" />
   </application>
 </manifest>

--- a/simplified-cardcreator/build.gradle
+++ b/simplified-cardcreator/build.gradle
@@ -19,6 +19,7 @@ dependencies {
   implementation libs.joda.time
   implementation libs.moshi
   implementation libs.moshi.kotlin
+  implementation libs.nypl.theme
   implementation libs.retrofit2
   implementation libs.retrofit2.moshi
   implementation libs.okhttp3.logging.interceptor

--- a/simplified-cardcreator/src/main/res/layout/fragment_juvenile_policy.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_juvenile_policy.xml
@@ -46,7 +46,6 @@
         android:layout_marginTop="5dp"
         tools:text="@string/legal_disclaimer"
         android:textSize="12sp"
-        android:textColor="@android:color/black"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/eula_checkbox"
         app:layout_constraintTop_toBottomOf="@id/policy_checkbox" />

--- a/simplified-cardcreator/src/main/res/values/styles.xml
+++ b/simplified-cardcreator/src/main/res/values/styles.xml
@@ -25,7 +25,6 @@
         <item name="android:layout_marginLeft">8dp</item>
         <item name="android:layout_marginRight">8dp</item>
         <item name="android:textSize">16sp</item>
-        <item name="android:textColor">@color/trans_black</item>
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:gravity">center</item>
     </style>
@@ -43,7 +42,6 @@
     <style name="WizardFormLabel">
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:textAppearance">?android:textAppearanceSmall</item>
-        <item name="android:textColor">@color/trans_black</item>
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:textAllCaps">true</item>
     </style>
@@ -51,7 +49,6 @@
     <style name="WizardFormEditText">
         <item name="android:inputType">textCapWords</item>
         <item name="android:saveEnabled">false</item>
-        <item name="android:textColorHint">@color/trans_grey</item>
         <item name="android:fontFamily">sans-serif</item>
     </style>
 
@@ -61,7 +58,6 @@
         <item name="android:layout_marginLeft">8dp</item>
         <item name="android:layout_marginRight">8dp</item>
         <item name="android:textAppearance">?android:textAppearanceSmall</item>
-        <item name="android:textColor">@color/text_light</item>
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:textAllCaps">false</item>
     </style>
@@ -69,7 +65,6 @@
     <style name="WizardFormTextView">
         <item name="android:inputType">textCapWords</item>
         <item name="android:saveEnabled">false</item>
-        <item name="android:textColorHint">@color/text_hint</item>
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:textAppearance">?android:textAppearanceMedium</item>
     </style>


### PR DESCRIPTION
**What's this do?**
Here module specific text color has been removed, and the Simplified Android Theme a has been adopted.

**Why are we doing this? (w/ JIRA link if applicable)**
[SMA-280: Jr card creation screens appear difficult to read with dark mode on](https://jira.nypl.org/browse/SMA-280)

**How should this be tested? / Do these changes have associated tests?**
Sign into a NYPL account, and attempt to create a child card. Examine the screens in dark mode and verify all text is visible.

**Dependencies for merging? Releasing to production?**
n/a

**Have you updated the changelog?**
TBD

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 
