### PR TITLE
Fix IA logins

### DIFF
--- a/simplified-patron/src/main/java/org/nypl/simplified/patron/PatronUserProfileParser.kt
+++ b/simplified-patron/src/main/java/org/nypl/simplified/patron/PatronUserProfileParser.kt
@@ -221,7 +221,8 @@ internal class PatronUserProfileParser(
   private fun parseAuthorization(root: ObjectNode): PatronAuthorization? {
     return try {
       val identifier =
-        JSONParserUtilities.getString(root, "simplified:authorization_identifier")
+        JSONParserUtilities.getStringOrNull(root, "simplified:authorization_identifier")
+          ?: return null
       val expires =
         JSONParserUtilities.getStringOrNull(root, "simplified:authorization_expires")
           ?.let { text -> ISODateTimeFormat.dateTimeParser().parseDateTime(text) }
@@ -235,7 +236,9 @@ internal class PatronUserProfileParser(
 
   private fun parseSettings(root: ObjectNode): PatronSettings {
     return try {
-      val settingsRoot = JSONParserUtilities.getObject(root, "settings")
+      val settingsRoot =
+        JSONParserUtilities.getObjectOrNull(root, "settings")
+          ?: return PatronSettings(synchronizeAnnotations = false)
 
       val synchronizeAnnotations =
         when (settingsRoot["simplified:synchronize_annotations"]) {

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedEntryParserTest.java
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedEntryParserTest.java
@@ -7,11 +7,14 @@ import com.io7m.jfunctional.Some;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.nypl.simplified.books.book_database.api.BookAcquisitionSelection;
+import org.nypl.simplified.books.borrowing.BorrowAcquisitions;
 import org.nypl.simplified.opds.core.DRMLicensor;
 import org.nypl.simplified.opds.core.OPDSAcquisition;
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry;
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntryParser;
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntryParserType;
+import org.nypl.simplified.opds.core.OPDSAcquisitionPath;
 import org.nypl.simplified.opds.core.OPDSAvailabilityHeld;
 import org.nypl.simplified.opds.core.OPDSAvailabilityHeldReady;
 import org.nypl.simplified.opds.core.OPDSAvailabilityHoldable;
@@ -21,6 +24,7 @@ import org.nypl.simplified.opds.core.OPDSAvailabilityOpenAccess;
 import org.nypl.simplified.opds.core.OPDSAvailabilityType;
 import org.nypl.simplified.opds.core.OPDSDateParsers;
 import org.nypl.simplified.opds.core.OPDSIndirectAcquisition;
+import org.nypl.simplified.tests.books.BookFormatsTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -451,6 +455,24 @@ public final class OPDSFeedEntryParserTest {
     Assertions.assertEquals(
       Option.some("http://qa.circulation.librarysimplified.org/NYNYPL/AdobeAuth/devices"),
       licensor.getDeviceManager());
+  }
+
+  @Test
+  public void testSMA83()
+    throws Exception {
+    final OPDSAcquisitionFeedEntryParserType parser = this.getParser();
+    final OPDSAcquisitionFeedEntry e = parser.parseEntryStream(URI.create("urn:test"),
+      OPDSFeedEntryParserTest.getResource("entry-SMA-83.xml"));
+
+    final OPDSAcquisitionPath path =
+      BorrowAcquisitions.INSTANCE.pickBestAcquisitionPath(
+        BookFormatsTesting.INSTANCE.getSupportsEverything(),
+        e
+      );
+    Assertions.assertEquals(
+      "application/atom+xml",
+      path.component1().component3().getFullType()
+    );
   }
 
   private OPDSAcquisitionFeedEntryParserType getParser() {

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/patron/PatronUserProfileParserContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/patron/PatronUserProfileParserContract.kt
@@ -26,7 +26,14 @@ abstract class PatronUserProfileParserContract {
 
     val result = parser.parse()
     this.dump(result)
-    ExtraAssertions.assertInstanceOf(result, Failure::class.java)
+    ExtraAssertions.assertInstanceOf(result, Success::class.java)
+
+    val success = result as Success
+    val profile = success.result
+
+    Assertions.assertEquals(null, profile.authorization)
+    Assertions.assertEquals(false, profile.settings.synchronizeAnnotations)
+    Assertions.assertEquals(0, profile.drm.size)
   }
 
   @Test

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/entry-SMA-83.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/entry-SMA-83.xml
@@ -1,0 +1,43 @@
+<entry xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog"
+  xmlns="http://www.w3.org/2005/Atom">
+  <title>The time machine</title>
+  <id>urn:x-internet-archive:bookserver:item:timemachinebanta00hgwe</id>
+  <updated>2011-06-22T22:04:28Z</updated>
+  <link href="https://bookserver.archive.org/borrow/webview/timemachinebanta00hgwe" rel="http://opds-spec.org/acquisition/borrow"
+    type="text/html">
+    <opds:availability status="available" />
+    <opds:holds total="0" />
+    <opds:copies available="1" total="1" />
+    <opds:indirectAcquisition type="application/vnd.adobe.adept+xml">
+      <opds:indirectAcquisition type="application/epub+zip" />
+    </opds:indirectAcquisition>
+  </link>
+  <link href="https://bookserver.archive.org/borrow/timemachinebanta00hgwe"
+    rel="http://opds-spec.org/acquisition/borrow"
+    type="application/atom+xml;type=entry;profile=opds-catalog">
+    <opds:availability status="available" />
+    <opds:holds total="0" />
+    <opds:copies available="1" total="1" />
+    <opds:indirectAcquisition type="application/vnd.adobe.adept+xml">
+      <opds:indirectAcquisition type="application/epub+zip" />
+    </opds:indirectAcquisition>
+  </link>
+  <link href="http://archive.org/download/timemachinebanta00hgwe/page/cover_medium.jpg"
+    rel="http://opds-spec.org/image" type="image/jpeg" />
+  <link href="http://archive.org/download/timemachinebanta00hgwe/page/cover_medium.jpg"
+    rel="http://opds-spec.org/image/thumbnail" type="image/jpeg" />
+  <dcterms:issued>1991</dcterms:issued>
+  <published>1991-01-01T00:00:00Z</published>
+  <author>
+    <name>Wells, H. G. (Herbert George), 1866-1946</name>
+  </author>
+  <category label="Science fiction" term="Science fiction" />
+  <category label="Time travel" term="Time travel" />
+  <category label="Science fiction" term="Science fiction" />
+  <category label="Science fiction" term="Science fiction" />
+  <dcterms:publisher>New York, NY : Bantam Books</dcterms:publisher>
+  <dcterms:language>en</dcterms:language>
+  <summary type="html">Relates the adventures of a scientist who invents a machine that transports
+    him into the future
+  </summary>
+</entry>


### PR DESCRIPTION
**What's this do?**
This makes the changes necessary to log into Archive.org.  This
basically meant making the patron user profile parser more permissive,
because they don't include information that we'd essentially set as
required in the parser (despite the information being optional).

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/SMA-171

**How should this be tested? / Do these changes have associated tests?**
Check that you can log in to the internet archive using an email address and password.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m logged in:

![device-2021-12-01-151452](https://user-images.githubusercontent.com/612494/144260791-7b5a1c8c-aff9-451e-8f62-50f11567bdb0.png)
