### PR TITLE
SMA-295: When creating a library card, send an appropriate value for the "location" field

### DIFF
--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorDebugging.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorDebugging.kt
@@ -1,15 +1,28 @@
 package org.nypl.simplified.cardcreator
 
+import android.location.Location
+
 /**
  * The debugging interface to the Card Creator.
  */
 
 object CardCreatorDebugging {
 
-  /*
-   * Set to `true` if the Card Creator should pretend that the user is in New York.
-   */
+  private val newYorkCityLocation: Location =
+    Location("").apply {
+      latitude = 40.6454199
+      longitude = -73.9537622
+    }
 
-  @Volatile
-  var fakeNewYorkLocation: Boolean = false
+  private val albanyLocation: Location =
+    Location("").apply {
+      latitude = 42.6680631
+      longitude = -73.8807209
+    }
+
+  /*
+ * Set to `newYorkCityLocation` or `albanyLocation` to pretend the user is in New York City or Albany.
+ */
+
+  val fakeLocation: Location? = null
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Patron.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Patron.kt
@@ -3,6 +3,7 @@ package org.nypl.simplified.cardcreator.model
 import com.squareup.moshi.Json
 
 data class Patron(
+  @field:Json(name = "location") val location: String,
   @field:Json(name = "policy_type") val policy_type: String,
   @field:Json(name = "address") val address: Address,
   @field:Json(name = "email") val email: String,

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ReviewFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ReviewFragment.kt
@@ -22,6 +22,7 @@ import org.nypl.simplified.cardcreator.model.Patron
 import org.nypl.simplified.cardcreator.utils.Cache
 import org.nypl.simplified.cardcreator.utils.getCache
 import org.nypl.simplified.cardcreator.utils.isBarcode
+import org.nypl.simplified.cardcreator.viewmodel.CardCreatorViewModel
 import org.nypl.simplified.cardcreator.viewmodel.PatronViewModel
 import org.slf4j.LoggerFactory
 
@@ -41,6 +42,7 @@ class ReviewFragment : Fragment() {
   private val policyTypeDefault = "simplye"
 
   private val viewModel: PatronViewModel by activityViewModels()
+  private val activityModel: CardCreatorViewModel by activityViewModels()
 
   private var dialog: AlertDialog? = null
 
@@ -199,10 +201,16 @@ class ReviewFragment : Fragment() {
     val accountInformation = cache.getAccountInformation()
     val workAddress = cache.getWorkAddress()
     val schoolAddress = cache.getSchoolAddress()
+    val deviceAddress = checkNotNull(activityModel.userLocationAddress)
+    val deviceZipCode = deviceAddress.postalCode.toIntOrNull()
+    val isInNewYorkCity = deviceZipCode != null &&
+      deviceZipCode in ((10001..10499) + (11001..11499) + (11601..11699))
+    val location = if (isInNewYorkCity) "nyc" else "nys"
 
     when {
       cache.getHomeAddress().state == nyState -> {
         return Patron(
+          location,
           policyTypeDefault,
           homeAddress,
           personalInformation.email,
@@ -217,6 +225,7 @@ class ReviewFragment : Fragment() {
       }
       cache.getSchoolAddress().line1.isEmpty() -> {
         return Patron(
+          location,
           policyTypeDefault,
           homeAddress,
           personalInformation.email,
@@ -231,6 +240,7 @@ class ReviewFragment : Fragment() {
       }
       else -> {
         return Patron(
+          location,
           policyTypeDefault,
           homeAddress,
           personalInformation.email,

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/CardCreatorViewModel.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/CardCreatorViewModel.kt
@@ -1,8 +1,12 @@
 package org.nypl.simplified.cardcreator.viewmodel
 
+import android.location.Address
 import androidx.lifecycle.ViewModel
 import org.nypl.simplified.cardcreator.network.CardCreatorService
 
 class CardCreatorViewModel(
   val cardCreatorService: CardCreatorService
-) : ViewModel()
+) : ViewModel() {
+
+  var userLocationAddress: Address? = null
+}

--- a/simplified-cardcreator/src/main/res/values/strings.xml
+++ b/simplified-cardcreator/src/main/res/values/strings.xml
@@ -151,7 +151,7 @@
     <string name="cancel">Cancel</string>
     <string name="settings">Settings</string>
     <string name="new_york_success">We have successfully determined that you are in New York!</string>
-    <string name="location_permission_prompt">SimplyE needs access to you location in order to create a library card.</string>
+    <string name="location_permission_prompt">SimplyE needs access to your location in order to create a library card.</string>
     <string name="location_access_error">SimplyE cannot access your device\'s location, configure your location settings to continue.</string>
 
     <!-- Accessibility -->

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
@@ -34,7 +34,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
 
   private lateinit var adobeDRMActivationTable: TableLayout
   private lateinit var cacheButton: Button
-  private lateinit var cardCreatorFakeLocation: SwitchCompat
   private lateinit var crashButton: Button
   private lateinit var crashlyticsId: TextView
   private lateinit var customOPDS: Button
@@ -77,8 +76,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       view.findViewById(R.id.settingsVersionDevFailNextBootSwitch)
     this.hasSeenLibrarySelection =
       view.findViewById(R.id.settingsVersionDevSeenLibrarySelectionScreen)
-    this.cardCreatorFakeLocation =
-      view.findViewById(R.id.settingsVersionDevCardCreatorLocationSwitch)
     this.showOnlySupportedBooks =
       view.findViewById(R.id.settingsVersionDevShowOnlySupported)
     this.customOPDS =
@@ -107,8 +104,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       this.viewModel.isBootFailureEnabled
     this.hasSeenLibrarySelection.isChecked =
       this.viewModel.hasSeenLibrarySelection
-    this.cardCreatorFakeLocation.isChecked =
-      this.viewModel.cardCreatorFakeLocation
     this.showOnlySupportedBooks.isChecked =
       this.viewModel.showOnlySupportedBooks
     this.crashlyticsId.text =
@@ -189,10 +184,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
 
     this.hasSeenLibrarySelection.setOnCheckedChangeListener { _, checked ->
       this.viewModel.hasSeenLibrarySelection = checked
-    }
-
-    this.cardCreatorFakeLocation.setOnCheckedChangeListener { _, checked ->
-      this.viewModel.cardCreatorFakeLocation = checked
     }
 
     /*

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
@@ -20,7 +20,6 @@ import org.nypl.simplified.analytics.api.AnalyticsType
 import org.nypl.simplified.books.controller.api.BooksControllerType
 import org.nypl.simplified.boot.api.BootFailureTesting
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
-import org.nypl.simplified.cardcreator.CardCreatorDebugging
 import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
 import org.nypl.simplified.feeds.api.FeedLoaderType
 import org.nypl.simplified.profiles.api.ProfileEvent
@@ -108,14 +107,6 @@ class SettingsDebugViewModel(application: Application) : AndroidViewModel(applic
 
   val adeptActivations: LiveData<List<AdobeDRMExtensions.Activation>> =
     fetchAdeptActivations()
-
-  var cardCreatorFakeLocation: Boolean
-    get() =
-      CardCreatorDebugging.fakeNewYorkLocation
-    set(value) {
-      this.logger.debug("card creator fake location: {}", value)
-      CardCreatorDebugging.fakeNewYorkLocation = value
-    }
 
   var showOnlySupportedBooks: Boolean
     get() =

--- a/simplified-ui-settings/src/main/res/layout/settings_debug.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_debug.xml
@@ -182,16 +182,6 @@
       android:text="User has seen library selection screen?" />
 
     <androidx.appcompat.widget.SwitchCompat
-      android:id="@+id/settingsVersionDevCardCreatorLocationSwitch"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      android:checked="false"
-      android:enabled="true"
-      android:visibility="gone"
-      android:text="Card Creator: Pretend the user is in New York" />
-
-    <androidx.appcompat.widget.SwitchCompat
       android:id="@+id/settingsVersionDevShowOnlySupported"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"


### PR DESCRIPTION
**What's this do?**
- When creating a library card, send an appropriate value for the "location" field
- Suppress the fake location in the UI. It had been disabled and was unlikely to be ever enabled again.

This is the worst code I've ever written. The flow was difficult to keep track of in `LocationFragment` so I made minimal changes hoping it will work. I didn't want to entirely rewrite the UI because we're supposed to get rid of the native card creator soon or later.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SMA-295

**How should this be tested? / Do these changes have associated tests?**
Check you can get a permanent card both when you're in New York City, and when you're outside of it but in the New York State.
The card duration can be checked on nypl.org

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
I did with fake locations. This should also be tested in real conditions as the code slightly diverges.