### PR TITLE
SMA-297: Update NYPL HTTP Android Library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,9 @@ plugins {
 
 ext {
   android_build_tools_version = "30.0.2"
-  android_compile_sdk_version = 30
+  android_compile_sdk_version = 31
   android_min_sdk_version = 21
-  android_target_sdk_version = 30
+  android_target_sdk_version = 31
 
   // Required for some dependencies only available from our private S3
   //

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorContract.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorContract.kt
@@ -41,9 +41,9 @@ class CardCreatorContract(
       USER_IDENTIFIER_KEY to input.userIdentifier
     )
 
-  override fun parseResult(resultCode: Int, intent: Intent?): Output? =
+  override fun parseResult(resultCode: Int, intent: Intent?): Output =
     if (intent == null || resultCode != Activity.RESULT_OK) {
-      null
+      Output("", "")
     } else {
       this.parseResult(intent.extras!!)
     }

--- a/simplified-ui-accounts/build.gradle
+++ b/simplified-ui-accounts/build.gradle
@@ -27,7 +27,12 @@ dependencies {
   implementation libs.androidx.app.compat
   implementation libs.androidx.constraint.layout
   implementation libs.androidx.lifecycle.ext
+
   implementation libs.androidx.fragment
+  //fragment-ktx pulls in viewModel-ktx. We need to explicitly declare the latest viewModel-ktx
+  //to force fragment-ktx to use the latest viewModel-ktx and avoid duplicate class collisions
+  implementation libs.androidx.lifecycle.viewmodel.ktx
+
   implementation libs.androidx.recycler.view
   implementation libs.google.material
   implementation libs.kotlin.stdlib

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModelFactory.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModelFactory.kt
@@ -15,7 +15,7 @@ class AccountDetailViewModelFactory(
 ) : ViewModelProvider.Factory {
 
   @Suppress("UNCHECKED_CAST")
-  override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+  override fun <T : ViewModel> create(modelClass: Class<T>): T {
     if (modelClass == AccountDetailViewModel::class.java) {
       return AccountDetailViewModel(
         accountId = this.account,

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/saml20/AccountSAML20ViewModelFactory.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/saml20/AccountSAML20ViewModelFactory.kt
@@ -17,7 +17,7 @@ class AccountSAML20ViewModelFactory(
 ) : ViewModelProvider.Factory {
 
   @Suppress("UNCHECKED_CAST")
-  override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+  override fun <T : ViewModel> create(modelClass: Class<T>): T {
     if (modelClass == AccountSAML20ViewModel::class.java) {
       return AccountSAML20ViewModel(
         application = this.application,

--- a/simplified-ui-announcements/build.gradle
+++ b/simplified-ui-announcements/build.gradle
@@ -8,5 +8,9 @@ dependencies {
   implementation libs.androidx.constraint.layout
   implementation libs.androidx.lifecycle.ext
   implementation libs.androidx.core.ktx
+
   implementation libs.androidx.fragment
+  //fragment-ktx pulls in viewModel-ktx. We need to explicitly declare the latest viewModel-ktx
+  //to force fragment-ktx to use the latest viewModel-ktx and avoid duplicate class collisions
+  implementation libs.androidx.lifecycle.viewmodel.ktx
 }

--- a/simplified-ui-announcements/src/main/java/org/nypl/simplified/ui/announcements/AnnouncementsViewModelFactory.kt
+++ b/simplified-ui-announcements/src/main/java/org/nypl/simplified/ui/announcements/AnnouncementsViewModelFactory.kt
@@ -9,7 +9,7 @@ class AnnouncementsViewModelFactory(
   private val services: ServiceDirectoryType
 ) : ViewModelProvider.Factory {
 
-  override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+  override fun <T : ViewModel> create(modelClass: Class<T>): T {
     return when {
       modelClass.isAssignableFrom(AnnouncementsViewModel::class.java) -> {
         val profilesController: ProfilesControllerType =

--- a/simplified-ui-catalog/build.gradle
+++ b/simplified-ui-catalog/build.gradle
@@ -31,7 +31,12 @@ dependencies {
   implementation project(":simplified-ui-thread-api")
 
   implementation libs.androidx.core
+
   implementation libs.androidx.fragment
+  //fragment-ktx pulls in viewModel-ktx. We need to explicitly declare the latest viewModel-ktx
+  //to force fragment-ktx to use the latest viewModel-ktx and avoid duplicate class collisions
+  implementation libs.androidx.lifecycle.viewmodel.ktx
+
   implementation libs.androidx.app.compat
   implementation libs.androidx.cardview
   implementation libs.androidx.constraint.layout

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/saml20/CatalogSAML20ViewModelFactory.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/saml20/CatalogSAML20ViewModelFactory.kt
@@ -21,7 +21,7 @@ class CatalogSAML20ViewModelFactory(
   private val webViewDataDir: File
 ) : ViewModelProvider.Factory {
 
-  override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+  override fun <T : ViewModel> create(modelClass: Class<T>): T {
     if (modelClass == CatalogSAML20ViewModel::class.java) {
       val profilesController =
         services.requireService(ProfilesControllerType::class.java)

--- a/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogFeedFragmentTest.kt
+++ b/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogFeedFragmentTest.kt
@@ -439,7 +439,7 @@ object RecyclerViewEspressoUtils {
 }
 
 // PagedList stuff
-fun <T> List<T>.asPagedList() = LivePagedListBuilder(
+fun <T: Any> List<T>.asPagedList() = LivePagedListBuilder(
   createMockDataSourceFactory(this),
   Config(
     enablePlaceholders = false,
@@ -448,13 +448,13 @@ fun <T> List<T>.asPagedList() = LivePagedListBuilder(
   )
 ).build()
 
-private fun <T> createMockDataSourceFactory(itemList: List<T>): DataSource.Factory<Int, T> =
+private fun <T: Any> createMockDataSourceFactory(itemList: List<T>): DataSource.Factory<Int, T> =
   object : DataSource.Factory<Int, T>() {
     override fun create(): DataSource<Int, T> = FakePositionalDataSource(itemList)
   }
 
 // Revisit this to use PageKeyedDataSource (as CatalogPagedDataSource does)
-class FakePositionalDataSource<T>(private val itemList: List<T>) : PositionalDataSource<T>() {
+class FakePositionalDataSource<T: Any>(private val itemList: List<T>) : PositionalDataSource<T>() {
   override fun loadInitial(params: LoadInitialParams, callback: LoadInitialCallback<T>) {
     callback.onResult(itemList, 0)
   }

--- a/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogFeedFragmentTest.kt
+++ b/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogFeedFragmentTest.kt
@@ -439,7 +439,7 @@ object RecyclerViewEspressoUtils {
 }
 
 // PagedList stuff
-fun <T: Any> List<T>.asPagedList() = LivePagedListBuilder(
+fun <T : Any> List<T>.asPagedList() = LivePagedListBuilder(
   createMockDataSourceFactory(this),
   Config(
     enablePlaceholders = false,
@@ -448,13 +448,13 @@ fun <T: Any> List<T>.asPagedList() = LivePagedListBuilder(
   )
 ).build()
 
-private fun <T: Any> createMockDataSourceFactory(itemList: List<T>): DataSource.Factory<Int, T> =
+private fun <T : Any> createMockDataSourceFactory(itemList: List<T>): DataSource.Factory<Int, T> =
   object : DataSource.Factory<Int, T>() {
     override fun create(): DataSource<Int, T> = FakePositionalDataSource(itemList)
   }
 
 // Revisit this to use PageKeyedDataSource (as CatalogPagedDataSource does)
-class FakePositionalDataSource<T: Any>(private val itemList: List<T>) : PositionalDataSource<T>() {
+class FakePositionalDataSource<T : Any>(private val itemList: List<T>) : PositionalDataSource<T>() {
   override fun loadInitial(params: LoadInitialParams, callback: LoadInitialCallback<T>) {
     callback.onResult(itemList, 0)
   }

--- a/simplified-ui-onboarding/build.gradle
+++ b/simplified-ui-onboarding/build.gradle
@@ -9,7 +9,12 @@ dependencies {
 
   implementation libs.androidx.app.compat
   implementation libs.androidx.lifecycle.ext
+
   implementation libs.androidx.fragment
+  //fragment-ktx pulls in viewModel-ktx. We need to explicitly declare the latest viewModel-ktx
+  //to force fragment-ktx to use the latest viewModel-ktx and avoid duplicate class collisions
+  implementation libs.androidx.lifecycle.viewmodel.ktx
+
   implementation libs.google.material
   implementation libs.io7m.jfunctional
   implementation libs.io7m.junreachable

--- a/simplified-ui-splash/build.gradle
+++ b/simplified-ui-splash/build.gradle
@@ -15,7 +15,12 @@ dependencies {
   implementation libs.androidx.constraint.layout
   implementation libs.androidx.legacy.support.v4
   implementation libs.androidx.lifecycle.ext
+
   implementation libs.androidx.fragment
+  //fragment-ktx pulls in viewModel-ktx. We need to explicitly declare the latest viewModel-ktx
+  //to force fragment-ktx to use the latest viewModel-ktx and avoid duplicate class collisions
+  implementation libs.androidx.lifecycle.viewmodel.ktx
+
   implementation libs.google.material
   implementation libs.io7m.jfunctional
   implementation libs.io7m.junreachable

--- a/simplified-viewer-epub-readium2/build.gradle
+++ b/simplified-viewer-epub-readium2/build.gradle
@@ -9,7 +9,12 @@ dependencies {
 
   implementation libs.androidx.activity
   implementation libs.androidx.app.compat
+
   implementation libs.androidx.fragment
+  //fragment-ktx pulls in viewModel-ktx. We need to explicitly declare the latest viewModel-ktx
+  //to force fragment-ktx to use the latest viewModel-ktx and avoid duplicate class collisions
+  implementation libs.androidx.lifecycle.viewmodel.ktx
+
   implementation libs.androidx.lifecycle.ext
   implementation libs.androidx.lifecycle.viewmodel
   implementation libs.kotlin.stdlib


### PR DESCRIPTION
**What's this do?**
This PR bumps the platform submodule to point to a new version using NYPL Http Android 0.0.25-SNAPSHOT

**Why are we doing this? (w/ JIRA link if applicable)**
Keeping dependencies up-to-date

https://jira.nypl.org/browse/SMA-297

**How should this be tested? / Do these changes have associated tests?**

Ensure the app and its associated tests run/function normally

**Dependencies for merging? Releasing to production?**
No required dependencies.

**Has the application documentation been updated for these changes?**
No documentation changes

**Did someone actually run this code to verify it works?**
I ran the app on my Pixel 2 device and bounced around a few screens without issue.