### PR TITLE
SMA-312: Add support for AxisNow in SimplyE and prioritize DRMs

### DIFF
--- a/.ci-local/check-repositories.txt
+++ b/.ci-local/check-repositories.txt
@@ -7,4 +7,3 @@ https://repo1.maven.org/maven2/
 http://maven.findawayworld.com/artifactory/libs-release/
 https://jcenter.bintray.com/
 https://jitpack.io/
-https://dl.google.com/dl/android/maven2/

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/NYPL-Simplified/Simplified-Android-C
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/NYPL-Simplified/Simplified-Android-Core
 POM_SCM_URL=http://github.com/NYPL-Simplified/Simplified-Android-Core
 POM_URL=http://github.com/NYPL-Simplified/Simplified-Android-Core
-VERSION_NAME=7.0.3-SNAPSHOT
+VERSION_NAME=7.3.0-SNAPSHOT
 VERSION_CODE_BASE=70000
 
 android.useAndroidX=true

--- a/simplified-app-simplye/build.gradle
+++ b/simplified-app-simplye/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 
   if (nyplS3Depend) {
     implementation libs.nypl.drm.adobe
+    implementation libs.nypl.drm.axis
   }
   annotationProcessor libs.google.auto.value.processor
 }

--- a/simplified-books-formats-api/src/main/java/org/nypl/simplified/books/formats/api/BookFormatSupportType.kt
+++ b/simplified-books-formats-api/src/main/java/org/nypl/simplified/books/formats/api/BookFormatSupportType.kt
@@ -32,4 +32,12 @@ interface BookFormatSupportType {
    */
 
   fun isDRMSupported(drmKind: BookDRMKind): Boolean
+
+  /**
+   * @return the DRM kind associated with the given acquisition path if any
+   */
+
+  fun getDRMKind(
+    typePath: List<MIMEType>
+  ): BookDRMKind
 }

--- a/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupport.kt
+++ b/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupport.kt
@@ -2,13 +2,8 @@ package org.nypl.simplified.books.formats
 
 import one.irradia.mime.api.MIMEType
 import org.nypl.simplified.books.api.BookDRMKind
-import org.nypl.simplified.books.api.BookDRMKind.ACS
-import org.nypl.simplified.books.api.BookDRMKind.AXIS
-import org.nypl.simplified.books.api.BookDRMKind.LCP
-import org.nypl.simplified.books.api.BookDRMKind.NONE
 import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import org.nypl.simplified.books.formats.api.StandardFormatNames
-import org.nypl.simplified.opds.core.OPDSAcquisitionPath
 import org.slf4j.LoggerFactory
 
 /**
@@ -148,10 +143,10 @@ class BookFormatSupport private constructor(
 
   override fun isDRMSupported(drmKind: BookDRMKind): Boolean {
     return when (drmKind) {
-      NONE -> true
-      LCP -> this.parameters.supportsLCP
-      ACS -> this.parameters.supportsAdobeDRM
-      AXIS -> this.parameters.supportsAxisNow
+      BookDRMKind.NONE -> true
+      BookDRMKind.LCP -> this.parameters.supportsLCP
+      BookDRMKind.ACS -> this.parameters.supportsAdobeDRM
+      BookDRMKind.AXIS -> this.parameters.supportsAxisNow
     }
   }
 
@@ -160,13 +155,13 @@ class BookFormatSupport private constructor(
   ): BookDRMKind {
 
     if (StandardFormatNames.adobeACSMFiles in typePath) {
-      return ACS
+      return BookDRMKind.ACS
     }
 
     if (StandardFormatNames.axisNow in typePath) {
-      return AXIS
+      return BookDRMKind.AXIS
     }
 
-    return NONE
+    return BookDRMKind.NONE
   }
 }

--- a/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupport.kt
+++ b/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupport.kt
@@ -8,6 +8,7 @@ import org.nypl.simplified.books.api.BookDRMKind.LCP
 import org.nypl.simplified.books.api.BookDRMKind.NONE
 import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import org.nypl.simplified.books.formats.api.StandardFormatNames
+import org.nypl.simplified.opds.core.OPDSAcquisitionPath
 import org.slf4j.LoggerFactory
 
 /**
@@ -152,5 +153,20 @@ class BookFormatSupport private constructor(
       ACS -> this.parameters.supportsAdobeDRM
       AXIS -> this.parameters.supportsAxisNow
     }
+  }
+
+  override fun getDRMKind(
+    typePath: List<MIMEType>
+  ): BookDRMKind {
+
+    if (StandardFormatNames.adobeACSMFiles in typePath) {
+      return ACS
+    }
+
+    if (StandardFormatNames.axisNow in typePath) {
+      return AXIS
+    }
+
+    return NONE
   }
 }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowAcquisitionsTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowAcquisitionsTest.kt
@@ -24,7 +24,6 @@ class BorrowAcquisitionsTest {
     return url.openStream()
   }
 
-
   @Test
   fun adobeIsPreferredOverAxis() {
     val support =

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowAcquisitionsTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowAcquisitionsTest.kt
@@ -1,0 +1,48 @@
+package org.nypl.simplified.tests.books.borrowing
+
+import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.nypl.simplified.books.borrowing.BorrowAcquisitions
+import org.nypl.simplified.books.formats.BookFormatSupport
+import org.nypl.simplified.books.formats.BookFormatSupportParameters
+import org.nypl.simplified.books.formats.api.StandardFormatNames
+import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntryParser
+import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntryParserType
+import java.io.FileNotFoundException
+import java.io.InputStream
+import java.net.URI
+
+class BorrowAcquisitionsTest {
+
+  private val parser: OPDSAcquisitionFeedEntryParserType =
+    OPDSAcquisitionFeedEntryParser.newParser()
+
+  private fun getResource(name: String): InputStream {
+    val path = "/org/nypl/simplified/tests/books/$name"
+    val url = BorrowAcquisitionsTest::class.java.getResource(path)
+      ?: throw FileNotFoundException(path)
+    return url.openStream()
+  }
+
+
+  @Test
+  fun adobeIsPreferredOverAxis() {
+    val support =
+      BookFormatSupport.create(
+        BookFormatSupportParameters(
+          supportsLCP = true,
+          supportsAudioBooks = null,
+          supportsAxisNow = true,
+          supportsPDF = false,
+          supportsAdobeDRM = true
+        )
+      )
+
+    val resourceStream = getResource("borrow-multiple-drm.xml")
+    val entry = parser.parseEntryStream(URI.create("urn:test"), resourceStream)
+    val bestPath = BorrowAcquisitions.pickBestAcquisitionPath(support, entry)
+      ?.asMIMETypes().orEmpty()
+
+    Assertions.assertTrue(bestPath.contains(StandardFormatNames.adobeACSMFiles))
+  }
+}

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/formats/BookFormatSupportTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/formats/BookFormatSupportTest.kt
@@ -2,6 +2,7 @@ package org.nypl.simplified.tests.books.formats
 
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.nypl.simplified.books.api.BookDRMKind
 import org.nypl.simplified.books.formats.BookFormatAudioSupportParameters
 import org.nypl.simplified.books.formats.BookFormatSupport
 import org.nypl.simplified.books.formats.BookFormatSupportParameters
@@ -111,6 +112,81 @@ class BookFormatSupportTest {
       supportWithout.isSupportedPath(
         listOf(
           StandardFormatNames.adobeACSMFiles,
+          StandardFormatNames.genericEPUBFiles
+        )
+      )
+    )
+  }
+
+  /**
+   * Acquisition paths through ACS are associated with BookDRMKind.ACS.
+   */
+
+  @Test
+  fun testDRMKindAdobe() {
+    val support =
+      BookFormatSupport.create(
+        BookFormatSupportParameters(
+          supportsPDF = false,
+          supportsLCP = false,
+          supportsAdobeDRM = true,
+          supportsAxisNow = false,
+          supportsAudioBooks = null
+        )
+      )
+    Assertions.assertEquals(
+      BookDRMKind.ACS,
+      support.getDRMKind(
+        listOf(
+          StandardFormatNames.adobeACSMFiles,
+          StandardFormatNames.genericEPUBFiles
+        )
+      )
+    )
+  }
+
+  /**
+   * Acquisition paths through AxisNow are associated with BookDRMKind.AXIS.
+   */
+
+  @Test
+  fun testDRMKindAxis() {
+    val support =
+      BookFormatSupport.create(
+        BookFormatSupportParameters(
+          supportsPDF = false,
+          supportsLCP = false,
+          supportsAdobeDRM = false,
+          supportsAxisNow = true,
+          supportsAudioBooks = null
+        )
+      )
+    Assertions.assertEquals(
+      BookDRMKind.AXIS,
+      support.getDRMKind(
+        listOf(
+          StandardFormatNames.axisNow
+        )
+      )
+    )
+  }
+
+  @Test
+  fun testDRMKindNone() {
+    val support =
+      BookFormatSupport.create(
+        BookFormatSupportParameters(
+          supportsPDF = false,
+          supportsLCP = false,
+          supportsAdobeDRM = false,
+          supportsAxisNow = false,
+          supportsAudioBooks = null
+        )
+      )
+    Assertions.assertEquals(
+      BookDRMKind.NONE,
+      support.getDRMKind(
+        listOf(
           StandardFormatNames.genericEPUBFiles
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookFormatSupport.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookFormatSupport.kt
@@ -23,4 +23,8 @@ class MockBookFormatSupport : BookFormatSupportType {
   override fun isDRMSupported(drmKind: BookDRMKind): Boolean {
     return true
   }
+
+  override fun getDRMKind(typePath: List<MIMEType>): BookDRMKind {
+    return BookDRMKind.NONE
+  }
 }

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/borrow-multiple-drm.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/borrow-multiple-drm.xml
@@ -1,0 +1,92 @@
+<entry xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/"
+    xmlns:simplified="http://librarysimplified.org/terms/" xmlns="http://www.w3.org/2005/Atom"
+    schema:additionalType="http://schema.org/EBook">
+    <title>The Hands-off Manager</title>
+    <author>
+        <name>Duane Black</name>
+        <link rel="contributor"
+            type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+            title="Duane Black"
+            href="https://circulation.librarysimplified.org/NYNYPL/works/contributor/Duane%20Black/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult"/>
+    </author>
+    <author>
+        <name>Steve Chandler</name>
+        <link rel="contributor"
+            type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+            title="Steve Chandler"
+            href="https://circulation.librarysimplified.org/NYNYPL/works/contributor/Steve%20Chandler/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult"/>
+    </author>
+    <summary type="html">The number one reason cited in exit interviews for an employee quitting is...</summary>
+    <simplified:pwid>7b6cc84f-9679-0b35-47f8-f11746810689</simplified:pwid>
+    <link
+        rel="http://opds-spec.org/image"
+        href="http://contentcafecloud.baker-taylor.com/Jacket.svc/D65D0665-050A-487B-9908-16E6D8FF5C3E/9781601635921/Large/Logo"
+        type="image/png"/>
+    <link
+        rel="http://opds-spec.org/image/thumbnail"
+        href="http://contentcafecloud.baker-taylor.com/Jacket.svc/D65D0665-050A-487B-9908-16E6D8FF5C3E/9781601635921/Medium/Logo"
+        type="image/png"/>
+    <category
+        scheme="http://librarysimplified.org/terms/fiction/"
+        term="http://librarysimplified.org/terms/fiction/Nonfiction"
+        label="Nonfiction"/>
+    <category
+        scheme="http://librarysimplified.org/terms/genres/Simplified/"
+        term="http://librarysimplified.org/terms/genres/Simplified/Management%20%26%20Leadership"
+        label="Management &amp; Leadership"/>
+    <category
+        scheme="http://schema.org/audience"
+        term="Adult"
+        label="Adult"/>
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Red Wheel Weiser</dcterms:publisher>
+    <dcterms:issued>2012-03-22</dcterms:issued>
+    <link
+        rel="issues"
+        href="https://circulation.librarysimplified.org/NYNYPL/works/Axis%20360%20ID/0010862813/report"/>
+    <id>urn:librarysimplified.org/terms/id/Axis%20360%20ID/0010862813</id>
+    <link
+        rel="alternate"
+        href="https://circulation.librarysimplified.org/NYNYPL/works/Axis%20360%20ID/0010862813"
+        type="application/atom+xml;type=entry;profile=opds-catalog" />
+    <bibframe:distribution bibframe:ProviderName="Axis 360"/>
+    <published>2021-07-30T00:00:00Z</published>
+    <updated>2022-02-07T19:45:43+00:00</updated>
+    <link
+        type="application/atom+xml;type=entry;profile=opds-catalog"
+        rel="http://opds-spec.org/acquisition/borrow"
+        href="https://circulation.librarysimplified.org/NYNYPL/works/Axis%20360%20ID/0010862813/borrow/2">
+        <opds:indirectAcquisition type="application/vnd.adobe.adept+xml">
+            <opds:indirectAcquisition type="application/epub+zip"/>
+        </opds:indirectAcquisition>
+        <opds:availability status="available"/>
+        <opds:holds total="0"/>
+        <opds:copies total="2" available="2"/>
+    </link>
+    <link
+        type="application/atom+xml;type=entry;profile=opds-catalog"
+        rel="http://opds-spec.org/acquisition/borrow"
+        href="https://circulation.librarysimplified.org/NYNYPL/works/Axis%20360%20ID/0010862813/borrow/28">
+        <opds:indirectAcquisition type="application/vnd.librarysimplified.axisnow+json"/>
+        <opds:availability status="available"/>
+        <opds:holds total="0"/>
+        <opds:copies total="2" available="2"/>
+    </link>
+    <link
+        rel="recommendations"
+        type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+        title="Recommended Works"
+        href="https://circulation.librarysimplified.org/NYNYPL/works/Axis%20360%20ID/0010862813/recommendations" />
+    <link
+        rel="related" type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+        title="Recommended Works"
+        href="https://circulation.librarysimplified.org/NYNYPL/works/Axis%20360%20ID/0010862813/related_books" />
+    <link
+        rel="http://www.w3.org/ns/oa#annotationService"
+        type="application/ld+json; profile=&quot;http://www.w3.org/ns/anno.jsonld&quot;"
+        href="https://circulation.librarysimplified.org/NYNYPL/annotations/Axis%20360%20ID/0010862813" />
+    <link
+        rel="http://librarysimplified.org/terms/rel/analytics/open-book"
+        href="https://circulation.librarysimplified.org/NYNYPL/analytics/Axis%20360%20ID/0010862813/open_book" />
+</entry>


### PR DESCRIPTION
**What's this do?**
Add support for AxisNow in SimplyE and prioritize Adept over AxisNow.

**Why are we doing this? (w/ JIRA link if applicable)**
AxisNow support is added for banned books.

**How should this be tested? / Do these changes have associated tests?**
Check Adept is used when both DRM systems are available. Check AxisNow-protected books can be borrowed and read.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Yes, I did.
