### PR TITLE
SMA-321: SimplyE Collection should be renamed to Book for All

### DIFF
--- a/simplified-app-simplye/src/main/java/org/nypl/simplified/simplye/SimplyEAccountFallback.kt
+++ b/simplified-app-simplye/src/main/java/org/nypl/simplified/simplye/SimplyEAccountFallback.kt
@@ -24,7 +24,7 @@ class SimplyEAccountFallback : AccountProviderFallbackType {
       authenticationAlternatives = listOf(),
       cardCreatorURI = null,
       catalogURI = URI.create("https://circulation.librarysimplified.org/CLASSICS/groups/1832"),
-      displayName = "The SimplyE Collection",
+      displayName = "Books for All",
       eula = null,
       id = URI.create("urn:uuid:56906f26-2c9a-4ae9-bd02-552557720b99"),
       idNumeric = -1,

--- a/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaAccountFallback.kt
+++ b/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaAccountFallback.kt
@@ -24,7 +24,7 @@ class VanillaAccountFallback : AccountProviderFallbackType {
       authenticationAlternatives = listOf(),
       cardCreatorURI = null,
       catalogURI = URI.create("https://circulation.librarysimplified.org/CLASSICS/groups/1832"),
-      displayName = "The SimplyE Collection",
+      displayName = "Books for All",
       eula = null,
       id = URI.create("urn:uuid:56906f26-2c9a-4ae9-bd02-552557720b99"),
       idNumeric = -1,

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/accounts/descriptions/libraryregistry-qa.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/accounts/descriptions/libraryregistry-qa.json
@@ -7700,7 +7700,7 @@
         "updated": "2019-02-15T19:26:53Z",
         "description": "A selection of classics and modern material available to anyone, with no library card necessary.",
         "id": "urn:uuid:56906f26-2c9a-4ae9-bd02-552557720b99",
-        "title": "The SimplyE Collection"
+        "title": "Books for All"
       }
     },
     {

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/accounts/descriptions/libraryregistry.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/accounts/descriptions/libraryregistry.json
@@ -2079,7 +2079,7 @@
         "updated": "2019-02-15T19:26:53Z",
         "description": "A selection of classics and modern material available to anyone, with no library card necessary.",
         "id": "urn:uuid:56906f26-2c9a-4ae9-bd02-552557720b99",
-        "title": "The SimplyE Collection"
+        "title": "Books for All"
       }
     },
     {

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/accounts/providers-all.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/accounts/providers-all.json
@@ -3135,7 +3135,7 @@
   {
     "@version": "20190708",
     "addAutomatically": false,
-    "displayName": "The SimplyE Collection",
+    "displayName": "Books for All",
     "idNumeric": 2,
     "idUUID": "urn:uuid:56906f26-2c9a-4ae9-bd02-552557720b99",
     "isProduction": true,

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/accounts/providers-simplye.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/accounts/providers-simplye.json
@@ -2,7 +2,7 @@
   {
     "@version": "20190708",
     "addAutomatically": false,
-    "displayName": "The SimplyE Collection",
+    "displayName": "Books for All",
     "idNumeric": 2,
     "idUUID": "urn:uuid:56906f26-2c9a-4ae9-bd02-552557720b99",
     "isProduction": true,

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/analytics-20190509.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/analytics-20190509.xml
@@ -304,10 +304,10 @@
   </entry>
   <link href="https://circulation.librarysimplified.org/CLASSICS/groups/" rel="start" title="All Books"/>
   <link href="https://circulation.librarysimplified.org/CLASSICS/search/1831?q=corner&amp;after=10&amp;entrypoint=Book&amp;size=10" rel="next"/>
-  <link href="https://circulation.librarysimplified.org/CLASSICS/groups/1831" rel="up" title="The SimplyE Collection"/>
+  <link href="https://circulation.librarysimplified.org/CLASSICS/groups/1831" rel="up" title="Books for All"/>
   <simplified:breadcrumbs>
     <link href="https://circulation.librarysimplified.org/CLASSICS/groups/" title="All Books"/>
-    <link href="https://circulation.librarysimplified.org/CLASSICS/groups/1831" title="The SimplyE Collection"/>
+    <link href="https://circulation.librarysimplified.org/CLASSICS/groups/1831" title="Books for All"/>
   </simplified:breadcrumbs>
   <link href="https://circulation.librarysimplified.org/CLASSICS/authentication_document" rel="http://opds-spec.org/auth/document"/>
   <link href="https://circulation.librarysimplified.org/CLASSICS/search/1831?entrypoint=Book" type="application/opensearchdescription+xml" rel="search"/>

--- a/simplified-ui-onboarding/src/main/res/values/strings.xml
+++ b/simplified-ui-onboarding/src/main/res/values/strings.xml
@@ -4,6 +4,6 @@
   <!-- Onboarding start screen strings -->
   <string name="selectionTitle">Read E-Books from Your Library</string>
   <string name="selectionButton">Find Your Library</string>
-  <string name="selectionAlternateTitle">Browse the SimplyE Collection</string>
+  <string name="selectionAlternateTitle">Browse Books for All</string>
   <string name="selectionAlternateButton">Add a Library Later</string>
 </resources>

--- a/simplified-ui-splash/src/main/res/values/strings.xml
+++ b/simplified-ui-splash/src/main/res/values/strings.xml
@@ -14,6 +14,6 @@
   <!-- Library selection screen strings -->
   <string name="selectionTitle">Read E-Books from Your Library</string>
   <string name="selectionButton">Find Your Library</string>
-  <string name="selectionAlternateTitle">Browse the SimplyE Collection</string>
+  <string name="selectionAlternateTitle">Browse Books for All</string>
   <string name="selectionAlternateButton">Add a Library Later</string>
 </resources>


### PR DESCRIPTION
**What's this do?**
All hard-coded references of `SimplyE Collection` have been updated to `Library for All`

**Why are we doing this? (w/ JIRA link if applicable)**
[SMA-321: SimplyE Collection should be renamed to Book for All](https://jira.nypl.org/browse/SMA-321)

**How should this be tested? / Do these changes have associated tests?**
Launch the app and examine the intro screen.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 
