### PR TITLE
SMA-324: Fix crashes due to NPE when home is pressed at a wrong time

### DIFF
--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigator.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigator.kt
@@ -70,7 +70,7 @@ class TabbedNavigator private constructor (private val navigator: BottomNavigato
   }
 
   fun popToRoot(): Boolean {
-    val isAtRootOfStack = (1 == this.navigator.currentStackSize())
+    val isAtRootOfStack = (backStackSize() == 0)
     if (isAtRootOfStack) {
       return false // Nothing to do
     }
@@ -80,7 +80,8 @@ class TabbedNavigator private constructor (private val navigator: BottomNavigato
   }
 
   fun backStackSize(): Int {
-    // Note: currentStackSize() is not safe to call here as it may throw an NPE.
+    // Note: currentStackSize() is not always safe to call as it may throw an NPE
+    // if this.navigator.currentTab() == -1.
     return this.navigator.stackSize(this.navigator.currentTab()) - 1
   }
 }


### PR DESCRIPTION
**What's this do?**
Fix crashes due to NPE when home is pressed at a wrong time

**Why are we doing this? (w/ JIRA link if applicable)**
https://console.firebase.google.com/u/0/project/simplye-nypl/crashlytics/app/android:org.nypl.simplified.simplye/issues/89477a5a6a5fd42984e8ff1770797e6a?time=last-seven-days&sessionEventKey=6214EA3101390001194C4182D3C9CAAC_1645988764311394495

**How should this be tested? / Do these changes have associated tests?**
This cannot be tested.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Yes, I checked that things are not worse.