### PR TITLE
SMA-[307, 325, 331] Bugfixes for CardCreator results

### DIFF
--- a/build_test.gradle
+++ b/build_test.gradle
@@ -35,6 +35,7 @@ dependencies {
 
   // Espresso
   testImplementation libs.androidx.test.espresso.core
+  testImplementation 'androidx.test.espresso:espresso-intents:3.5.0-alpha03'
 
   // Assertions
   testImplementation libs.kluent.android

--- a/simplified-cardcreator/build.gradle
+++ b/simplified-cardcreator/build.gradle
@@ -1,6 +1,10 @@
+apply plugin: 'kotlin-kapt'
+
+apply from: "$rootProject.projectDir/build_test.gradle"
+
 android {
   buildFeatures {
-    viewBinding = true
+    dataBinding true
   }
 }
 
@@ -23,4 +27,8 @@ dependencies {
   implementation libs.retrofit2
   implementation libs.retrofit2.moshi
   implementation libs.okhttp3.logging.interceptor
+
+  // Temporary workaround to force databinding codegen in Robolectric tests
+  // https://github.com/robolectric/robolectric/issues/3789
+  kaptTest libs.androidx.databinding.kapt
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorActivity.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorActivity.kt
@@ -1,5 +1,6 @@
 package org.nypl.simplified.cardcreator
 
+import android.app.Activity
 import android.graphics.Color
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -16,6 +17,13 @@ import org.nypl.simplified.cardcreator.viewmodel.CardCreatorViewModelFactory
  * Should be with startActivityForResult
  */
 class CardCreatorActivity : AppCompatActivity() {
+
+  companion object {
+    const val CARD_CREATED = Activity.RESULT_OK
+    const val CARD_CREATION_CANCELED = Activity.RESULT_CANCELED
+    const val CHILD_CARD_CREATED = Activity.RESULT_FIRST_USER
+    const val CARD_CREATION_ERROR = Activity.RESULT_FIRST_USER + 1
+  }
 
   private lateinit var binding: ActivityCardCreatorBinding
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AgeFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AgeFragment.kt
@@ -1,6 +1,5 @@
 package org.nypl.simplified.cardcreator.ui
 
-import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.Navigation
+import org.nypl.simplified.cardcreator.CardCreatorActivity
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentAgeBinding
 import org.nypl.simplified.cardcreator.utils.Cache
@@ -76,7 +76,7 @@ class AgeFragment : Fragment() {
         nextAction = AgeFragmentDirections.actionNext()
         navController.navigate(nextAction)
       } else {
-        requireActivity().setResult(Activity.RESULT_CANCELED)
+        requireActivity().setResult(CardCreatorActivity.CARD_CREATION_CANCELED)
         requireActivity().finish()
       }
     }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmationFragment.kt
@@ -26,7 +26,8 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.FileOutputStream
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Locale
+import java.util.Date
 
 class ConfirmationFragment : Fragment() {
 
@@ -54,7 +55,8 @@ class ConfirmationFragment : Fragment() {
     super.onViewCreated(view, savedInstanceState)
 
     binding.nameCard.text = confirmationFragmentArgs.name
-    binding.cardBarcode.text = getString(R.string.user_card_number, confirmationFragmentArgs.barcode)
+    binding.cardBarcode.text =
+      getString(R.string.user_card_number, confirmationFragmentArgs.barcode)
     binding.cardPin.text = getString(R.string.user_password, confirmationFragmentArgs.password)
     binding.headerStatusDescTv.text = confirmationFragmentArgs.message
 
@@ -69,7 +71,10 @@ class ConfirmationFragment : Fragment() {
 
     // Go to previous screen
     binding.prevBtn.setOnClickListener {
-      if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE)
+      if (ContextCompat.checkSelfPermission(
+          requireContext(),
+          Manifest.permission.WRITE_EXTERNAL_STORAGE
+        )
         != PackageManager.PERMISSION_GRANTED
       ) {
         logger.debug("Requesting storage permission")
@@ -105,7 +110,8 @@ class ConfirmationFragment : Fragment() {
           outStream.close()
           addCardToGallery(f)
 
-          Toast.makeText(requireContext(), getString(R.string.card_saved), Toast.LENGTH_SHORT).show()
+          Toast.makeText(requireContext(), getString(R.string.card_saved), Toast.LENGTH_SHORT)
+            .show()
         }
       } catch (e: Exception) {
         logger.error("Error creating digital card", e)
@@ -154,7 +160,10 @@ class ConfirmationFragment : Fragment() {
    * Returns result to caller with card details
    */
   private fun returnResult() {
-    val bundle = CardCreatorContract.createResult(confirmationFragmentArgs.barcode, confirmationFragmentArgs.password)
+    val bundle = CardCreatorContract.createResult(
+      confirmationFragmentArgs.barcode,
+      confirmationFragmentArgs.password
+    )
       .apply {
         putString("username", confirmationFragmentArgs.username)
         putString("message", confirmationFragmentArgs.message)

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmationFragment.kt
@@ -1,7 +1,6 @@
 package org.nypl.simplified.cardcreator.ui
 
 import android.Manifest
-import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
@@ -18,6 +17,7 @@ import androidx.fragment.app.Fragment
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import org.nypl.simplified.cardcreator.CardCreatorActivity
 import org.nypl.simplified.cardcreator.CardCreatorContract
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentConfirmationBinding
@@ -26,13 +26,14 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.FileOutputStream
 import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.Date
+import java.util.*
 
 class ConfirmationFragment : Fragment() {
 
   private val logger = LoggerFactory.getLogger(ConfirmationFragment::class.java)
-  private val bundle by lazy { ConfirmationFragmentArgs.fromBundle(requireArguments()) }
+  private val confirmationFragmentArgs by lazy {
+    ConfirmationFragmentArgs.fromBundle(requireArguments())
+  }
 
   private var _binding: FragmentConfirmationBinding? = null
   private val binding get() = _binding!!
@@ -52,10 +53,10 @@ class ConfirmationFragment : Fragment() {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
-    binding.nameCard.text = bundle.name
-    binding.cardBarcode.text = getString(R.string.user_card_number, bundle.barcode)
-    binding.cardPin.text = getString(R.string.user_password, bundle.password)
-    binding.headerStatusDescTv.text = bundle.message
+    binding.nameCard.text = confirmationFragmentArgs.name
+    binding.cardBarcode.text = getString(R.string.user_card_number, confirmationFragmentArgs.barcode)
+    binding.cardPin.text = getString(R.string.user_password, confirmationFragmentArgs.password)
+    binding.headerStatusDescTv.text = confirmationFragmentArgs.message
 
     val currentDate: String = SimpleDateFormat(dateFormat, Locale.getDefault()).format(Date())
     binding.issued.text = getString(R.string.issued_date, currentDate)
@@ -153,18 +154,18 @@ class ConfirmationFragment : Fragment() {
    * Returns result to caller with card details
    */
   private fun returnResult() {
-    val bundle = CardCreatorContract.createResult(bundle.barcode, bundle.password)
+    val bundle = CardCreatorContract.createResult(confirmationFragmentArgs.barcode, confirmationFragmentArgs.password)
       .apply {
-        putString("username", bundle.username)
-        putString("message", bundle.message)
+        putString("username", confirmationFragmentArgs.username)
+        putString("message", confirmationFragmentArgs.message)
       }
     val data = Intent().apply {
       putExtras(bundle)
     }
     if (requireActivity().intent.getBooleanExtra("isLoggedIn", false)) {
-      requireActivity().setResult(Activity.RESULT_CANCELED, data)
+      requireActivity().setResult(CardCreatorActivity.CHILD_CARD_CREATED, data)
     } else {
-      requireActivity().setResult(Activity.RESULT_OK, data)
+      requireActivity().setResult(CardCreatorActivity.CARD_CREATED, data)
     }
     Cache(requireContext()).clear()
     requireActivity().finish()

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/JuvenilePolicyFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/JuvenilePolicyFragment.kt
@@ -1,6 +1,5 @@
 package org.nypl.simplified.cardcreator.ui
 
-import android.app.Activity
 import android.graphics.Color
 import android.os.Bundle
 import android.text.SpannableString
@@ -18,6 +17,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.Navigation
+import org.nypl.simplified.cardcreator.CardCreatorActivity
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentJuvenilePolicyBinding
 import org.nypl.simplified.cardcreator.model.DependentEligibilityResponse
@@ -94,13 +94,13 @@ class JuvenilePolicyFragment : Fragment() {
       if (validateForm()) {
         getEligibility()
       } else {
-        requireActivity().setResult(Activity.RESULT_CANCELED)
+        requireActivity().setResult(CardCreatorActivity.CARD_CREATION_CANCELED)
         requireActivity().finish()
       }
     }
 
     val callback = requireActivity().onBackPressedDispatcher.addCallback(this) {
-      requireActivity().setResult(Activity.RESULT_CANCELED)
+      requireActivity().setResult(CardCreatorActivity.CARD_CREATION_CANCELED)
       requireActivity().finish()
     }
     callback.isEnabled = true
@@ -153,7 +153,7 @@ class JuvenilePolicyFragment : Fragment() {
     dialogBuilder.setMessage(message)
       .setCancelable(false)
       .setNegativeButton(getString(R.string.cancel)) { _, _ ->
-        requireActivity().setResult(Activity.RESULT_CANCELED)
+        requireActivity().setResult(CardCreatorActivity.CARD_CREATION_CANCELED)
         requireActivity().finish()
       }
     if (dialog == null) {

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
@@ -1,7 +1,6 @@
 package org.nypl.simplified.cardcreator.ui
 
 import android.Manifest
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -25,6 +24,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.Navigation
+import org.nypl.simplified.cardcreator.CardCreatorActivity
 import org.nypl.simplified.cardcreator.CardCreatorDebugging
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentLocationBinding
@@ -32,7 +32,7 @@ import org.nypl.simplified.cardcreator.utils.getCache
 import org.nypl.simplified.cardcreator.utils.startEllipses
 import org.nypl.simplified.cardcreator.viewmodel.CardCreatorViewModel
 import org.slf4j.LoggerFactory
-import java.util.Locale
+import java.util.*
 
 /**
  * The Location screens that gates users who are not in New York
@@ -119,8 +119,7 @@ class LocationFragment : Fragment(), LocationListener {
           navController.navigate(nextAction)
         }
       } else {
-        val data = Intent()
-        requireActivity().setResult(Activity.RESULT_CANCELED, data)
+        requireActivity().setResult(CardCreatorActivity.CARD_CREATION_CANCELED)
         requireActivity().finish()
       }
     }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
@@ -32,7 +32,7 @@ import org.nypl.simplified.cardcreator.utils.getCache
 import org.nypl.simplified.cardcreator.utils.startEllipses
 import org.nypl.simplified.cardcreator.viewmodel.CardCreatorViewModel
 import org.slf4j.LoggerFactory
-import java.util.*
+import java.util.Locale
 
 /**
  * The Location screens that gates users who are not in New York

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ReviewFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ReviewFragment.kt
@@ -1,6 +1,5 @@
 package org.nypl.simplified.cardcreator.ui
 
-import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -13,6 +12,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.Navigation
+import org.nypl.simplified.cardcreator.CardCreatorActivity
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentReviewBinding
 import org.nypl.simplified.cardcreator.model.CreatePatronResponse
@@ -132,7 +132,7 @@ class ReviewFragment : Fragment() {
       }
       .setNegativeButton(getString(R.string.quit)) { _, _ ->
         Cache(requireContext()).clear()
-        requireActivity().setResult(Activity.RESULT_CANCELED)
+        requireActivity().setResult(CardCreatorActivity.CARD_CREATION_CANCELED)
         requireActivity().finish()
       }
     if (dialog == null) {

--- a/simplified-cardcreator/src/main/res/layout/activity_card_creator.xml
+++ b/simplified-cardcreator/src/main/res/layout/activity_card_creator.xml
@@ -1,35 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/card_creator_container"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".CardCreatorActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/card_creator_nav_host_fragment"
-        android:name="androidx.navigation.fragment.NavHostFragment"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:defaultNavHost="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar"
-        app:navGraph="@navigation/nav_graph" />
-
-    <Toolbar
-        android:id="@+id/toolbar"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/card_creator_container"
         android:layout_width="match_parent"
-        android:layout_height="?actionBarSize"
-        android:background="@android:color/black"
-        android:navigationIcon="?homeAsUpIndicator"
-        android:title="@string/sign_up"
-        android:titleTextAppearance="@style/WizardToolbar"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:titleTextColor="@android:color/white"/>
+        android:layout_height="match_parent"
+        tools:context=".CardCreatorActivity">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/card_creator_nav_host_fragment"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:defaultNavHost="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            app:navGraph="@navigation/nav_graph" />
+
+        <Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?actionBarSize"
+            android:background="@android:color/black"
+            android:navigationIcon="?homeAsUpIndicator"
+            android:title="@string/sign_up"
+            android:titleTextAppearance="@style/WizardToolbar"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:titleTextColor="@android:color/white" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_account_information.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_account_information.xml
@@ -1,145 +1,148 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.AccountInformationFragment">
-
-    <TextView
-        android:id="@+id/header_tv"
-        style="@style/WizardHeader"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/account_information"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <ScrollView
-        android:id="@+id/form_sv"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingHorizontal="16dp"
-        android:scrollbarStyle="outsideOverlay"
-        app:layout_constraintBottom_toTopOf="@id/footer"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/header_tv"
-        app:layout_constraintVertical_bias="0.1">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <TextView
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/username" />
-
-            <EditText
-                android:id="@+id/username_et"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:digits="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-                android:hint="@string/required"
-                android:maxLength="25" />
-
-            <TextView
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/password" />
-
-            <EditText
-                android:id="@+id/password_et"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required"
-                android:maxLength="32"
-                tools:ignore="TextFields" />
-
-        </LinearLayout>
-
-    </ScrollView>
-
-    <LinearLayout
-        android:id="@+id/footer"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintVertical_bias="1">
-
-        <TextView
-            style="@style/WizardFooter"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingHorizontal="12dp"
-            android:text="@string/username_desc"
-            android:textSize="12sp" />
-
-        <LinearLayout
-            android:id="@+id/nav_buttons"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/prev_btn"
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="50dp"
-                android:layout_weight="1"
-                android:text="@string/previous"
-                android:textAllCaps="true" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/next_btn"
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="50dp"
-                android:layout_weight="1"
-                android:enabled="false"
-                android:text="@string/next"
-                android:textAllCaps="true" />
-        </LinearLayout>
-    </LinearLayout>
+    xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/loading"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/trans_white"
-        android:visibility="gone">
+        tools:context=".ui.AccountInformationFragment">
 
         <TextView
-            android:id="@+id/loading_tv"
-            android:layout_width="wrap_content"
+            android:id="@+id/header_tv"
+            style="@style/WizardHeader"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="sans-serif"
-            android:text="@string/validating_username"
-            android:textSize="16sp"
-            app:layout_constraintBottom_toTopOf="@id/progress"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-        <ProgressBar
-            android:id="@+id/progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:text="@string/account_information"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        <ScrollView
+            android:id="@+id/form_sv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="16dp"
+            android:scrollbarStyle="outsideOverlay"
+            app:layout_constraintBottom_toTopOf="@id/footer"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/header_tv"
+            app:layout_constraintVertical_bias="0.1">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/username" />
+
+                <EditText
+                    android:id="@+id/username_et"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:digits="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+                    android:hint="@string/required"
+                    android:maxLength="25" />
+
+                <TextView
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/password" />
+
+                <EditText
+                    android:id="@+id/password_et"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required"
+                    android:maxLength="32"
+                    tools:ignore="TextFields" />
+
+            </LinearLayout>
+
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/footer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintVertical_bias="1">
+
+            <TextView
+                style="@style/WizardFooter"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="12dp"
+                android:text="@string/username_desc"
+                android:textSize="12sp" />
+
+            <LinearLayout
+                android:id="@+id/nav_buttons"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/prev_btn"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="50dp"
+                    android:layout_weight="1"
+                    android:text="@string/previous"
+                    android:textAllCaps="true" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/next_btn"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="50dp"
+                    android:layout_weight="1"
+                    android:enabled="false"
+                    android:text="@string/next"
+                    android:textAllCaps="true" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/loading"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/trans_white"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/loading_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:fontFamily="sans-serif"
+                android:text="@string/validating_username"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toTopOf="@id/progress"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <ProgressBar
+                android:id="@+id/progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_age.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_age.xml
@@ -1,115 +1,117 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <ScrollView
-      android:layout_width="match_parent"
-      android:layout_height="0dp"
-      app:layout_constraintTop_toTopOf="parent"
-      app:layout_constraintBottom_toTopOf="@id/error"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:paddingVertical="32dp"
-          tools:context=".ui.AgeFragment">
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/error"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-            <TextView
-              android:id="@+id/description_tv"
-              style="@style/WizardDescription"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:text="@string/age_description"
-              app:layout_constraintEnd_toEndOf="parent"
-              app:layout_constraintStart_toStartOf="parent"
-              app:layout_constraintTop_toTopOf="parent" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingVertical="32dp"
+                tools:context=".ui.AgeFragment">
 
-            <RadioGroup
-              android:id="@+id/age_rg"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:orientation="horizontal"
-              app:layout_constraintEnd_toEndOf="parent"
-              app:layout_constraintStart_toStartOf="parent"
-              app:layout_constraintTop_toBottomOf="@+id/description_tv">
+                <TextView
+                    android:id="@+id/description_tv"
+                    style="@style/WizardDescription"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/age_description"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-                <RadioButton
-                  android:id="@+id/under_13_rb"
-                  android:layout_width="wrap_content"
-                  android:layout_height="wrap_content"
-                  android:layout_marginLeft="25dp"
-                  android:layout_marginTop="20dp"
-                  android:layout_marginRight="25dp"
-                  android:layout_marginBottom="20dp"
-                  android:layout_weight="1"
-                  android:text="@string/under_13" />
+                <RadioGroup
+                    android:id="@+id/age_rg"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/description_tv">
 
-                <RadioButton
-                  android:id="@+id/older_13_rb"
-                  android:layout_width="wrap_content"
-                  android:layout_height="wrap_content"
-                  android:layout_marginLeft="25dp"
-                  android:layout_marginTop="20dp"
-                  android:layout_marginRight="25dp"
-                  android:layout_marginBottom="20dp"
-                  android:layout_weight="1"
-                  android:text="@string/over_13" />
-            </RadioGroup>
+                    <RadioButton
+                        android:id="@+id/under_13_rb"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="25dp"
+                        android:layout_marginTop="20dp"
+                        android:layout_marginRight="25dp"
+                        android:layout_marginBottom="20dp"
+                        android:layout_weight="1"
+                        android:text="@string/under_13" />
 
-            <CheckBox
-              android:id="@+id/eula_checkbox"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_marginTop="5dp"
-              android:checked="false"
-              android:text="@string/eula_checkbox"
-              android:textSize="12sp"
-              app:layout_constraintStart_toStartOf="parent"
-              app:layout_constraintTop_toBottomOf="@id/age_rg" />
+                    <RadioButton
+                        android:id="@+id/older_13_rb"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="25dp"
+                        android:layout_marginTop="20dp"
+                        android:layout_marginRight="25dp"
+                        android:layout_marginBottom="20dp"
+                        android:layout_weight="1"
+                        android:text="@string/over_13" />
+                </RadioGroup>
 
-            <TextView
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:id="@+id/eula"
-              android:gravity="center"
-              android:text="@string/eula"
-              app:layout_constraintEnd_toEndOf="parent"
-              app:layout_constraintStart_toStartOf="parent"
-              app:layout_constraintTop_toBottomOf="@id/eula_checkbox"
-              />
+                <CheckBox
+                    android:id="@+id/eula_checkbox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
+                    android:checked="false"
+                    android:text="@string/eula_checkbox"
+                    android:textSize="12sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/age_rg" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <TextView
+                    android:id="@+id/eula"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:text="@string/eula"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/eula_checkbox" />
 
-    </ScrollView>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <TextView
-      android:id="@+id/error"
-      style="@style/WizardError"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:text="@string/age_error"
-      android:visibility="invisible"
-      app:layout_constraintBottom_toTopOf="@id/next_btn"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
+        </ScrollView>
 
-    <androidx.appcompat.widget.AppCompatButton
-      android:id="@+id/next_btn"
-      style="?android:attr/buttonBarButtonStyle"
-      android:layout_width="match_parent"
-      android:layout_height="50dp"
-      android:enabled="false"
-      android:gravity="center"
-      android:text="@string/next"
-      android:textAllCaps="true"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
+        <TextView
+            android:id="@+id/error"
+            style="@style/WizardError"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/age_error"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toTopOf="@id/next_btn"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/next_btn"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:enabled="false"
+            android:gravity="center"
+            android:text="@string/next"
+            android:textAllCaps="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_alternate_address.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_alternate_address.xml
@@ -1,188 +1,191 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:orientation="vertical"
-    android:layout_height="match_parent"
-    tools:context=".ui.AlternateAddressFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout
-        android:id="@+id/header"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/header_tv"
-            style="@style/WizardHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:text="Alternate Address" />
-
-        <TextView
-            android:id="@+id/header_status_desc_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:textColor="@color/red"
-            android:layout_marginTop="16sp"
-            android:layout_marginRight="8dp"
-            android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif"
-            android:gravity="center"
-            android:textSize="16sp" />
-    </LinearLayout>
-
-    <ScrollView
-        android:id="@+id/form"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:paddingLeft="16dp"
-        android:paddingTop="16dp"
-        android:paddingRight="16dp"
-        android:scrollbarStyle="outsideOverlay">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/tv_street_1"
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/street_1" />
-
-            <EditText
-                android:id="@+id/et_street_1"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required" />
-
-            <TextView
-                android:id="@+id/tv_street_2"
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/street_2" />
-
-            <EditText
-                android:id="@+id/et_street_2"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/optional" />
-
-            <TextView
-                android:id="@+id/tv_city"
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/city" />
-
-            <EditText
-                android:id="@+id/et_city"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required" />
-
-
-            <TextView
-                android:id="@+id/tv_state"
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/state" />
-
-            <Spinner
-                android:id="@+id/sp_state"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required"
-                android:maxLength="2" />
-
-            <TextView
-                android:id="@+id/tv_zip"
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/zip" />
-
-            <EditText
-                android:id="@+id/et_zip"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required"
-                android:inputType="number"
-                android:maxLength="5" />
-
-        </LinearLayout>
-    </ScrollView>
-
-    <LinearLayout
-        android:id="@+id/nav_buttons"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/prev_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/previous"
-            android:textAllCaps="true" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/next_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:enabled="false"
-            android:text="@string/next"
-            android:textAllCaps="true" />
-
-    </LinearLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/loading"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/trans_white"
-        android:visibility="gone">
+        android:orientation="vertical"
+        tools:context=".ui.AlternateAddressFragment">
 
-        <TextView
-            android:id="@+id/loading_tv"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/header"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="sans-serif"
-            android:text="@string/checking_location"
-            android:textSize="16sp"
-            app:layout_constraintBottom_toTopOf="@id/progress"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-        <ProgressBar
-            android:id="@+id/progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:orientation="vertical"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/header_tv"
+                style="@style/WizardHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:text="Alternate Address" />
 
-</LinearLayout>
+            <TextView
+                android:id="@+id/header_status_desc_tv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginRight="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:gravity="center"
+                android:textColor="@color/red"
+                android:textSize="16sp" />
+        </LinearLayout>
+
+        <ScrollView
+            android:id="@+id/form"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:paddingLeft="16dp"
+            android:paddingTop="16dp"
+            android:paddingRight="16dp"
+            android:scrollbarStyle="outsideOverlay">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/tv_street_1"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/street_1" />
+
+                <EditText
+                    android:id="@+id/et_street_1"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required" />
+
+                <TextView
+                    android:id="@+id/tv_street_2"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/street_2" />
+
+                <EditText
+                    android:id="@+id/et_street_2"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/optional" />
+
+                <TextView
+                    android:id="@+id/tv_city"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/city" />
+
+                <EditText
+                    android:id="@+id/et_city"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required" />
+
+
+                <TextView
+                    android:id="@+id/tv_state"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/state" />
+
+                <Spinner
+                    android:id="@+id/sp_state"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required"
+                    android:maxLength="2" />
+
+                <TextView
+                    android:id="@+id/tv_zip"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/zip" />
+
+                <EditText
+                    android:id="@+id/et_zip"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required"
+                    android:inputType="number"
+                    android:maxLength="5" />
+
+            </LinearLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/nav_buttons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/prev_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/previous"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/next_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:enabled="false"
+                android:text="@string/next"
+                android:textAllCaps="true" />
+
+        </LinearLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/loading"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/trans_white"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/loading_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:fontFamily="sans-serif"
+                android:text="@string/checking_location"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toTopOf="@id/progress"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <ProgressBar
+                android:id="@+id/progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_confirm_alternate_address.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_confirm_alternate_address.xml
@@ -1,90 +1,93 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.ConfirmAlternateAddressFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <LinearLayout
-        android:id="@+id/header"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent"
+        tools:context=".ui.ConfirmAlternateAddressFragment">
 
-        <TextView
-            android:id="@+id/header_error_tv"
-            style="@style/WizardHeader"
+        <LinearLayout
+            android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/confirm_work_address" />
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/header_status_desc_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif"
-            android:gravity="center"
-            android:text="@string/confirm_address_subheader"
-            android:textSize="16sp" />
-
-        <TextView
-            android:id="@+id/your_address_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginBottom="8dp"
-            android:text="@string/your_address" />
-
-        <RadioGroup
-            android:id="@+id/address_rg"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp">
-
-            <RadioButton
-                android:id="@+id/address_rb"
-                android:checked="true"
+            <TextView
+                android:id="@+id/header_error_tv"
+                style="@style/WizardHeader"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </RadioGroup>
-    </LinearLayout>
+                android:layout_height="wrap_content"
+                android:text="@string/confirm_work_address" />
 
-    <LinearLayout
-        android:id="@+id/nav_buttons"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+            <TextView
+                android:id="@+id/header_status_desc_tv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:gravity="center"
+                android:text="@string/confirm_address_subheader"
+                android:textSize="16sp" />
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/prev_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/previous"
-            android:textAllCaps="true" />
+            <TextView
+                android:id="@+id/your_address_tv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginBottom="8dp"
+                android:text="@string/your_address" />
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/next_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/confirm"
-            android:textAllCaps="true" />
+            <RadioGroup
+                android:id="@+id/address_rg"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp">
 
-    </LinearLayout>
+                <RadioButton
+                    android:id="@+id/address_rb"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:checked="true" />
+            </RadioGroup>
+        </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <LinearLayout
+            android:id="@+id/nav_buttons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/prev_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/previous"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/next_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/confirm"
+                android:textAllCaps="true" />
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_confirm_home_address.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_confirm_home_address.xml
@@ -1,90 +1,93 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.ConfirmHomeAddressFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <LinearLayout
-        android:id="@+id/header"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent"
+        tools:context=".ui.ConfirmHomeAddressFragment">
 
-        <TextView
-            android:id="@+id/header_error_tv"
-            style="@style/WizardHeader"
+        <LinearLayout
+            android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/confirm_address" />
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/header_status_desc_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif"
-            android:gravity="center"
-            android:text="@string/confirm_address_subheader"
-            android:textSize="16sp" />
-
-        <TextView
-            android:id="@+id/your_address_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginBottom="8dp"
-            android:text="@string/your_address" />
-
-        <RadioGroup
-            android:id="@+id/address_rg"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp">
-
-            <RadioButton
-                android:id="@+id/address_rb"
+            <TextView
+                android:id="@+id/header_error_tv"
+                style="@style/WizardHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:checked="true" />
-        </RadioGroup>
-    </LinearLayout>
+                android:text="@string/confirm_address" />
 
-    <LinearLayout
-        android:id="@+id/nav_buttons"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+            <TextView
+                android:id="@+id/header_status_desc_tv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:gravity="center"
+                android:text="@string/confirm_address_subheader"
+                android:textSize="16sp" />
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/prev_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/previous"
-            android:textAllCaps="true" />
+            <TextView
+                android:id="@+id/your_address_tv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginBottom="8dp"
+                android:text="@string/your_address" />
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/next_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/confirm"
-            android:textAllCaps="true" />
+            <RadioGroup
+                android:id="@+id/address_rg"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp">
 
-    </LinearLayout>
+                <RadioButton
+                    android:id="@+id/address_rb"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:checked="true" />
+            </RadioGroup>
+        </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <LinearLayout
+            android:id="@+id/nav_buttons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/prev_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/previous"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/next_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/confirm"
+                android:textAllCaps="true" />
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_confirmation.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_confirmation.xml
@@ -1,136 +1,139 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.ConfirmationFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <LinearLayout
-        android:id="@+id/header"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent"
+        tools:context=".ui.ConfirmationFragment">
 
-        <TextView
-            android:id="@+id/header_error_tv"
-            style="@style/WizardHeader"
+        <LinearLayout
+            android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/confirmation" />
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/header_status_desc_tv"
+            <TextView
+                android:id="@+id/header_error_tv"
+                style="@style/WizardHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/confirmation" />
+
+            <TextView
+                android:id="@+id/header_status_desc_tv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginRight="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:gravity="center"
+                android:textSize="16sp" />
+        </LinearLayout>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/library_card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginRight="8dp"
-            android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif"
-            android:gravity="center"
-            android:textSize="16sp" />
-    </LinearLayout>
+            android:layout_margin="16dp"
+            app:cardCornerRadius="20dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-    <androidx.cardview.widget.CardView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        app:cardCornerRadius="20dp"
-        android:id="@+id/library_card"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-        <RelativeLayout
+                <ImageView
+                    android:id="@+id/nypl_logo"
+                    android:layout_width="100dp"
+                    android:layout_height="50dp"
+                    android:layout_alignParentTop="true"
+                    android:layout_alignParentEnd="true"
+                    android:layout_margin="16dp"
+                    android:contentDescription="@string/nypl_logo"
+                    android:scaleType="fitCenter"
+                    android:src="@drawable/nypl_logo" />
+
+                <TextView
+                    android:id="@+id/name_card"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:textSize="22sp"
+                    android:textStyle="bold"
+                    tools:text="John Doe" />
+
+                <TextView
+                    android:id="@+id/card_barcode"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/nypl_logo"
+                    android:layout_margin="16dp"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    tools:text="Card Number: 3423 24242 24242 24242" />
+
+                <TextView
+                    android:id="@+id/card_pin"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/card_barcode"
+                    android:layout_margin="16dp"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    tools:text="Password: 3423 " />
+
+                <TextView
+                    android:id="@+id/issued"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/card_pin"
+                    android:layout_margin="16dp"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    tools:text="Issued: 12/12/2020" />
+
+            </RelativeLayout>
+
+        </androidx.cardview.widget.CardView>
+
+        <LinearLayout
+            android:id="@+id/nav_buttons"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
 
-            <ImageView
-                android:contentDescription="@string/nypl_logo"
-                android:layout_width="100dp"
-                android:src="@drawable/nypl_logo"
-                android:scaleType="fitCenter"
-                android:id="@+id/nypl_logo"
-                android:layout_margin="16dp"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentTop="true"
-                android:layout_height="50dp"/>
-
-            <TextView
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/prev_btn"
+                style="?android:attr/buttonBarButtonStyle"
                 android:layout_width="wrap_content"
-                android:id="@+id/name_card"
-                android:layout_margin="16dp"
-                tools:text ="John Doe"
-                android:textSize="22sp"
-                android:textStyle="bold"
-                android:layout_height="wrap_content"/>
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/save_card"
+                android:textAllCaps="true" />
 
-            <TextView
-                android:layout_below="@id/nypl_logo"
-                android:id="@+id/card_barcode"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                android:layout_margin="16dp"
-                tools:text="Card Number: 3423 24242 24242 24242"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:layout_margin="16dp"
-                android:layout_below="@id/card_barcode"
-                android:id="@+id/card_pin"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                tools:text="Password: 3423 "
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
-
-            <TextView
-                android:layout_margin="16dp"
-                android:layout_below="@id/card_pin"
-                android:id="@+id/issued"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                tools:text="Issued: 12/12/2020"
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/next_btn"
+                style="?android:attr/buttonBarButtonStyle"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/done"
+                android:textAllCaps="true" />
 
-        </RelativeLayout>
+        </LinearLayout>
 
-    </androidx.cardview.widget.CardView>
-
-    <LinearLayout
-        android:id="@+id/nav_buttons"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/prev_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/save_card"
-            android:textAllCaps="true" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/next_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/done"
-            android:textAllCaps="true" />
-
-    </LinearLayout>
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_eula.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_eula.xml
@@ -1,35 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:orientation="vertical"
-    android:layout_height="match_parent"
-    tools:context=".ui.EULAFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/loading"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:clickable="true"
         android:layout_height="match_parent"
-        android:background="@color/trans_white"
-        android:visibility="visible"
-        tools:ignore="KeyboardInaccessibleWidget">
+        android:orientation="vertical"
+        tools:context=".ui.EULAFragment">
 
-        <ProgressBar
-            android:id="@+id/progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <WebView
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/loading"
             android:layout_width="match_parent"
-            android:id="@+id/webview"
-            android:layout_height="match_parent"/>
+            android:layout_height="match_parent"
+            android:background="@color/trans_white"
+            android:clickable="true"
+            android:visibility="visible"
+            tools:ignore="KeyboardInaccessibleWidget">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <ProgressBar
+                android:id="@+id/progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-</LinearLayout>
+            <WebView
+                android:id="@+id/webview"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_home_address.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_home_address.xml
@@ -1,189 +1,192 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:orientation="vertical"
-    android:layout_height="match_parent"
-    tools:context=".ui.HomeAddressFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout
-        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/header_error_tv"
-            style="@style/WizardHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/home_address" />
-
-        <TextView
-            android:id="@+id/header_status_desc_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginRight="8dp"
-            android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif"
-            android:gravity="center"
-            android:textSize="16sp" />
-    </LinearLayout>
-
-    <ScrollView
-        android:id="@+id/form"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:paddingLeft="16dp"
-        android:paddingTop="16dp"
-        android:paddingRight="16dp"
-        android:scrollbarStyle="outsideOverlay">
+        tools:context=".ui.HomeAddressFragment">
 
         <LinearLayout
+            android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/tv_street_1"
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/street_1" />
-
-            <EditText
-                android:id="@+id/et_street_1"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required" />
-
-            <TextView
-                android:id="@+id/tv_street_2"
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/street_2" />
-
-            <EditText
-                android:id="@+id/et_street_2"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/optional" />
-
-            <TextView
-                android:id="@+id/tv_city"
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/city" />
-
-            <EditText
-                android:id="@+id/et_city"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required" />
-
-
-            <TextView
-                android:id="@+id/tv_state"
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/state" />
-
-            <Spinner
-                android:id="@+id/sp_state"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required"
-                android:maxLength="2" />
-
-            <TextView
-                android:id="@+id/tv_zip"
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/zip" />
-
-            <EditText
-                android:id="@+id/et_zip"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required"
-                android:inputType="number"
-                android:maxLength="5" />
-
-        </LinearLayout>
-    </ScrollView>
-
-    <LinearLayout
-        android:id="@+id/nav_buttons"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/prev_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/previous"
-            android:textAllCaps="true" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/next_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:enabled="false"
-            android:text="@string/next"
-            android:textAllCaps="true" />
-
-    </LinearLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/loading"
-        android:layout_width="match_parent"
-        android:clickable="true"
-        android:layout_height="match_parent"
-        android:background="@color/trans_white"
-        android:visibility="gone"
-        tools:ignore="KeyboardInaccessibleWidget">
-
-        <TextView
-            android:id="@+id/loading_tv"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="sans-serif"
-            android:text="@string/checking_location"
-            android:textSize="16sp"
-            app:layout_constraintBottom_toTopOf="@id/progress"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-        <ProgressBar
-            android:id="@+id/progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:orientation="vertical"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/header_error_tv"
+                style="@style/WizardHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/home_address" />
 
-</LinearLayout>
+            <TextView
+                android:id="@+id/header_status_desc_tv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginRight="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:gravity="center"
+                android:textSize="16sp" />
+        </LinearLayout>
+
+        <ScrollView
+            android:id="@+id/form"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:paddingLeft="16dp"
+            android:paddingTop="16dp"
+            android:paddingRight="16dp"
+            android:scrollbarStyle="outsideOverlay">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/tv_street_1"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/street_1" />
+
+                <EditText
+                    android:id="@+id/et_street_1"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required" />
+
+                <TextView
+                    android:id="@+id/tv_street_2"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/street_2" />
+
+                <EditText
+                    android:id="@+id/et_street_2"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/optional" />
+
+                <TextView
+                    android:id="@+id/tv_city"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/city" />
+
+                <EditText
+                    android:id="@+id/et_city"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required" />
+
+
+                <TextView
+                    android:id="@+id/tv_state"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/state" />
+
+                <Spinner
+                    android:id="@+id/sp_state"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required"
+                    android:maxLength="2" />
+
+                <TextView
+                    android:id="@+id/tv_zip"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/zip" />
+
+                <EditText
+                    android:id="@+id/et_zip"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required"
+                    android:inputType="number"
+                    android:maxLength="5" />
+
+            </LinearLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/nav_buttons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/prev_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/previous"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/next_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:enabled="false"
+                android:text="@string/next"
+                android:textAllCaps="true" />
+
+        </LinearLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/loading"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/trans_white"
+            android:clickable="true"
+            android:visibility="gone"
+            tools:ignore="KeyboardInaccessibleWidget">
+
+            <TextView
+                android:id="@+id/loading_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:fontFamily="sans-serif"
+                android:text="@string/checking_location"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toTopOf="@id/progress"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <ProgressBar
+                android:id="@+id/progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_juvenile_information.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_juvenile_information.xml
@@ -1,113 +1,116 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".ui.JuvenileInformationFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout
-        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/header_error_tv"
-            style="@style/WizardHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/personal_information" />
-
-        <TextView
-            android:id="@+id/header_status_desc_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginRight="8dp"
-            android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif"
-            android:gravity="center"
-            android:textSize="16sp" />
-    </LinearLayout>
-
-    <ScrollView
-        android:id="@+id/form"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:paddingLeft="16dp"
-        android:paddingTop="16dp"
-        android:paddingRight="16dp"
-        android:scrollbarStyle="outsideOverlay">
+        tools:context=".ui.JuvenileInformationFragment">
 
         <LinearLayout
+            android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-
-            <TextView
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/first_name" />
-
-            <EditText
-                android:id="@+id/first_name_et"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required"
-                android:inputType="text" />
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <TextView
-                style="@style/WizardFormLabel"
+                android:id="@+id/header_error_tv"
+                style="@style/WizardHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/last_name" />
+                android:text="@string/personal_information" />
 
-            <EditText
-                android:id="@+id/last_name_et"
-                style="@style/WizardFormEditText"
+            <TextView
+                android:id="@+id/header_status_desc_tv"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/optional"
-                android:inputType="text" />
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginRight="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:gravity="center"
+                android:textSize="16sp" />
+        </LinearLayout>
+
+        <ScrollView
+            android:id="@+id/form"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:paddingLeft="16dp"
+            android:paddingTop="16dp"
+            android:paddingRight="16dp"
+            android:scrollbarStyle="outsideOverlay">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+
+                <TextView
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/first_name" />
+
+                <EditText
+                    android:id="@+id/first_name_et"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required"
+                    android:inputType="text" />
+
+                <TextView
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/last_name" />
+
+                <EditText
+                    android:id="@+id/last_name_et"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/optional"
+                    android:inputType="text" />
+
+            </LinearLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/nav_buttons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/prev_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/previous"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/next_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:enabled="false"
+                android:text="@string/next"
+                android:textAllCaps="true" />
 
         </LinearLayout>
-    </ScrollView>
-
-    <LinearLayout
-        android:id="@+id/nav_buttons"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/prev_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/previous"
-            android:textAllCaps="true" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/next_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:enabled="false"
-            android:text="@string/next"
-            android:textAllCaps="true" />
 
     </LinearLayout>
-
-</LinearLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_juvenile_policy.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_juvenile_policy.xml
@@ -1,86 +1,89 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.JuvenilePolicyFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:id="@+id/description_tv"
-        style="@style/WizardDescription"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:gravity="start"
-        android:text="@string/juvenile_policy"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_height="match_parent"
+        tools:context=".ui.JuvenilePolicyFragment">
 
-    <CheckBox
-        android:id="@+id/policy_checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:checked="false"
-        android:text="@string/juvenile_policy_checkbox"
-        android:textSize="12sp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/description_tv" />
+        <TextView
+            android:id="@+id/description_tv"
+            style="@style/WizardDescription"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:gravity="start"
+            android:text="@string/juvenile_policy"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <CheckBox
-        android:id="@+id/eula_checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:checked="false"
-        android:textSize="12sp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/policy_checkbox" />
+        <CheckBox
+            android:id="@+id/policy_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:checked="false"
+            android:text="@string/juvenile_policy_checkbox"
+            android:textSize="12sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/description_tv" />
 
-    <TextView
-        android:id="@+id/eula"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        tools:text="@string/legal_disclaimer"
-        android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/eula_checkbox"
-        app:layout_constraintTop_toBottomOf="@id/policy_checkbox" />
+        <CheckBox
+            android:id="@+id/eula_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:checked="false"
+            android:textSize="12sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/policy_checkbox" />
 
-    <TextView
-        android:id="@+id/error"
-        style="@style/WizardError"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/age_error"
-        android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@id/next_btn"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        <TextView
+            android:id="@+id/eula"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/eula_checkbox"
+            app:layout_constraintTop_toBottomOf="@id/policy_checkbox"
+            tools:text="@string/legal_disclaimer" />
 
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/next_btn"
-        style="?android:attr/buttonBarButtonStyle"
-        android:layout_width="match_parent"
-        android:layout_height="50dp"
-        android:gravity="center"
-        android:text="@string/cancel"
-        android:textAllCaps="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        <TextView
+            android:id="@+id/error"
+            style="@style/WizardError"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/age_error"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/next_btn"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
-    <ProgressBar
-        android:id="@+id/progress"
-        android:layout_width="wrap_content"
-        android:visibility="gone"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/next_btn"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:gravity="center"
+            android:text="@string/cancel"
+            android:textAllCaps="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <ProgressBar
+            android:id="@+id/progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_location.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_location.xml
@@ -1,118 +1,123 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.LocationFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <LinearLayout
-        android:id="@+id/header"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent"
+        tools:context=".ui.LocationFragment">
 
-        <TextView
-            android:id="@+id/header_error_tv"
-            style="@style/WizardHeader"
+        <LinearLayout
+            android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/location_check" />
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-        <RelativeLayout
+            <TextView
+                android:id="@+id/header_error_tv"
+                style="@style/WizardHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/location_check" />
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/header_status_desc_tv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerHorizontal="true"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginTop="16sp"
+                    android:layout_marginBottom="8dp"
+                    android:fontFamily="sans-serif"
+                    android:text="@string/validating_location"
+                    android:textSize="16sp" />
+
+                <TextView
+                    android:id="@+id/ellipses_tv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerHorizontal="true"
+                    android:layout_marginTop="16sp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginBottom="8dp"
+                    android:layout_toEndOf="@id/header_status_desc_tv"
+                    android:fontFamily="sans-serif"
+                    android:textSize="16sp"
+                    tools:text="..." />
+
+            </RelativeLayout>
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/form_label_tv"
+            style="@style/WizardFormLabel"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-            <TextView
-                android:id="@+id/header_status_desc_tv"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="16sp"
-                android:layout_marginBottom="8dp"
-                android:fontFamily="sans-serif"
-                android:layout_centerHorizontal="true"
-                android:text="@string/validating_location"
-                android:textSize="16sp" />
-            <TextView
-                android:id="@+id/ellipses_tv"
-                android:layout_toEndOf="@id/header_status_desc_tv"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16sp"
-                android:layout_marginEnd="8dp"
-                android:layout_marginBottom="8dp"
-                android:fontFamily="sans-serif"
-                android:layout_centerHorizontal="true"
-                tools:text="..."
-                android:textSize="16sp" />
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="@string/location"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/header" />
 
-        </RelativeLayout>
-    </LinearLayout>
-
-    <TextView
-        android:id="@+id/form_label_tv"
-        style="@style/WizardFormLabel"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:text="@string/location"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/header" />
-
-    <EditText
-        android:id="@+id/region_et"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:enabled="false"
-        android:saveEnabled="false"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/form_label_tv" />
-
-    <Button
-        android:id="@+id/check_location_btn"
-        style="?android:attr/buttonBarButtonStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/check_location_again"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/region_et" />
-
-    <LinearLayout
-        android:id="@+id/nav_buttons"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/prev_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/previous"
-            android:textAllCaps="true" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/next_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
+        <EditText
+            android:id="@+id/region_et"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
             android:enabled="false"
-            android:text="@string/next"
-            android:textAllCaps="true" />
+            android:saveEnabled="false"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/form_label_tv" />
 
-    </LinearLayout>
+        <Button
+            android:id="@+id/check_location_btn"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/check_location_again"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/region_et" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <LinearLayout
+            android:id="@+id/nav_buttons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/prev_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/previous"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/next_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:enabled="false"
+                android:text="@string/next"
+                android:textAllCaps="true" />
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_out_of_state.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_out_of_state.xml
@@ -1,88 +1,91 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.OutOfStateFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <LinearLayout
-        android:id="@+id/header"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent"
+        tools:context=".ui.OutOfStateFragment">
 
-        <TextView
-            android:id="@+id/header_error_tv"
-            style="@style/WizardHeader"
+        <LinearLayout
+            android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/out_of_state_address" />
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/header_status_desc_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginRight="8dp"
-            android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif"
-            android:gravity="center"
-            android:text="@string/out_of_state_subheader"
-            android:textSize="16sp" />
-
-        <RadioGroup
-            android:id="@+id/address_rg"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp">
-
-            <RadioButton
-                android:id="@+id/work_rb"
+            <TextView
+                android:id="@+id/header_error_tv"
+                style="@style/WizardHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/work_in_ny" />
+                android:text="@string/out_of_state_address" />
 
-            <RadioButton
-                android:id="@+id/school_rb"
+            <TextView
+                android:id="@+id/header_status_desc_tv"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/school_in_ny" />
-        </RadioGroup>
-    </LinearLayout>
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginRight="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:gravity="center"
+                android:text="@string/out_of_state_subheader"
+                android:textSize="16sp" />
 
-    <LinearLayout
-        android:id="@+id/nav_buttons"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+            <RadioGroup
+                android:id="@+id/address_rg"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp">
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/prev_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/previous"
-            android:textAllCaps="true" />
+                <RadioButton
+                    android:id="@+id/work_rb"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/work_in_ny" />
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/next_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:enabled="false"
-            android:text="@string/next"
-            android:textAllCaps="true" />
+                <RadioButton
+                    android:id="@+id/school_rb"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/school_in_ny" />
+            </RadioGroup>
+        </LinearLayout>
 
-    </LinearLayout>
+        <LinearLayout
+            android:id="@+id/nav_buttons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/prev_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/previous"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/next_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:enabled="false"
+                android:text="@string/next"
+                android:textAllCaps="true" />
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_personal_information.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_personal_information.xml
@@ -1,160 +1,163 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".ui.PersonalInformationFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout
-        android:id="@+id/header"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/header_error_tv"
-            style="@style/WizardHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/personal_information" />
-
-        <TextView
-            android:id="@+id/header_status_desc_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginRight="8dp"
-            android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif"
-            android:gravity="center"
-            android:textSize="16sp" />
-    </LinearLayout>
-
-    <ScrollView
-        android:id="@+id/form"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:paddingLeft="16dp"
-        android:paddingTop="16dp"
-        android:paddingRight="16dp"
-        android:scrollbarStyle="outsideOverlay">
+        tools:context=".ui.PersonalInformationFragment">
 
         <LinearLayout
+            android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-
-            <TextView
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/first_name" />
-
-            <EditText
-                android:id="@+id/first_name_et"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required"
-                android:inputType="text" />
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <TextView
-                style="@style/WizardFormLabel"
+                android:id="@+id/header_error_tv"
+                style="@style/WizardHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/middle_name" />
-
-            <EditText
-                android:id="@+id/middle_name_et"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/optional"
-                android:inputType="text" />
+                android:text="@string/personal_information" />
 
             <TextView
-                style="@style/WizardFormLabel"
+                android:id="@+id/header_status_desc_tv"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/last_name" />
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginRight="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:gravity="center"
+                android:textSize="16sp" />
+        </LinearLayout>
 
-            <EditText
-                android:id="@+id/last_name_et"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required"
-                android:inputType="text" />
+        <ScrollView
+            android:id="@+id/form"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:paddingLeft="16dp"
+            android:paddingTop="16dp"
+            android:paddingRight="16dp"
+            android:scrollbarStyle="outsideOverlay">
 
-            <TextView
-                style="@style/WizardFormLabel"
-                android:id="@+id/birth_date_label"
-                android:clickable="true"
-                android:focusable="true"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/birth_date" />
+                android:orientation="vertical">
 
-            <EditText
-                android:id="@+id/birth_date_et"
-                android:clickable="true"
-                android:focusable="false"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required"
-                android:inputType="text" />
 
-            <TextView
-                style="@style/WizardFormLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/email" />
+                <TextView
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/first_name" />
 
-            <EditText
-                android:id="@+id/email_et"
-                style="@style/WizardFormEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/required"
-                android:inputType="textEmailAddress" />
+                <EditText
+                    android:id="@+id/first_name_et"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required"
+                    android:inputType="text" />
+
+                <TextView
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/middle_name" />
+
+                <EditText
+                    android:id="@+id/middle_name_et"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/optional"
+                    android:inputType="text" />
+
+                <TextView
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/last_name" />
+
+                <EditText
+                    android:id="@+id/last_name_et"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required"
+                    android:inputType="text" />
+
+                <TextView
+                    android:id="@+id/birth_date_label"
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:text="@string/birth_date" />
+
+                <EditText
+                    android:id="@+id/birth_date_et"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="false"
+                    android:hint="@string/required"
+                    android:inputType="text" />
+
+                <TextView
+                    style="@style/WizardFormLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/email" />
+
+                <EditText
+                    android:id="@+id/email_et"
+                    style="@style/WizardFormEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/required"
+                    android:inputType="textEmailAddress" />
+
+            </LinearLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/nav_buttons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/prev_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/previous"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/next_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:enabled="false"
+                android:text="@string/next"
+                android:textAllCaps="true" />
 
         </LinearLayout>
-    </ScrollView>
-
-    <LinearLayout
-        android:id="@+id/nav_buttons"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/prev_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/previous"
-            android:textAllCaps="true" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/next_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:enabled="false"
-            android:text="@string/next"
-            android:textAllCaps="true" />
 
     </LinearLayout>
-
-</LinearLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_review.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_review.xml
@@ -1,237 +1,240 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.ReviewFragment">
-
-    <LinearLayout
-        android:id="@+id/header"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/header_error_tv"
-            style="@style/WizardHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/review" />
-
-        <TextView
-            android:id="@+id/header_status_desc_tv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginRight="8dp"
-            android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif"
-            android:gravity="center"
-            android:textSize="16sp" />
-
-        <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingLeft="16dp"
-            android:paddingTop="16dp"
-            android:paddingRight="16dp"
-            android:scrollbarStyle="outsideOverlay">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <TextView
-                    style="@style/WizardFormLabel"
-                    android:id="@+id/address_home_label_tv"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/home_address" />
-
-                <TextView
-                    android:id="@+id/address_home_tv_1"
-                    style="@style/WizardFormTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <TextView
-                    android:id="@+id/address_home_tv_2"
-                    style="@style/WizardFormTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <LinearLayout
-                    android:id="@+id/work_address_data"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:visibility="gone">
-
-                    <TextView
-                        android:id="@+id/work_address_label_tv"
-                        style="@style/WizardFormLabel"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/work_address" />
-
-                    <TextView
-                        android:id="@+id/work_address_tv_1"
-                        style="@style/WizardFormTextView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-
-                    <TextView
-                        android:id="@+id/work_address_tv_2"
-                        style="@style/WizardFormTextView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/school_address_data"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:visibility="gone">
-
-                    <TextView
-                        android:id="@+id/school_address_label_tv"
-                        style="@style/WizardFormLabel"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/school_address" />
-
-                    <TextView
-                        android:id="@+id/school_address_tv_1"
-                        style="@style/WizardFormTextView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-
-                    <TextView
-                        android:id="@+id/school_address_tv_2"
-                        style="@style/WizardFormTextView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-                </LinearLayout>
-
-                <TextView
-                    style="@style/WizardFormLabel"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/name" />
-
-                <TextView
-                    android:id="@+id/name_tv"
-                    style="@style/WizardFormTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <TextView
-                    style="@style/WizardFormLabel"
-                    android:id="@+id/email_label_tv"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/email" />
-
-                <TextView
-                    android:id="@+id/email_tv"
-                    style="@style/WizardFormTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <TextView
-                    style="@style/WizardFormLabel"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/username" />
-
-                <TextView
-                    android:id="@+id/username_tv"
-                    style="@style/WizardFormTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <TextView
-                    style="@style/WizardFormLabel"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/password" />
-
-                <TextView
-                    android:id="@+id/pin_tv"
-                    style="@style/WizardFormTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-            </LinearLayout>
-        </ScrollView>
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/nav_buttons"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/prev_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/previous"
-            android:textAllCaps="true" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/next_btn"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:layout_weight="1"
-            android:text="@string/create_card"
-            android:textAllCaps="true" />
-
-    </LinearLayout>
+    xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/loading"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/trans_white"
-        android:clickable="true"
-        android:visibility="gone"
-        tools:ignore="KeyboardInaccessibleWidget">
+        tools:context=".ui.ReviewFragment">
 
-        <TextView
-            android:id="@+id/loading_tv"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/header"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="sans-serif"
-            android:text="@string/creating_card"
-            android:textSize="16sp"
-            app:layout_constraintBottom_toTopOf="@id/progress"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-        <ProgressBar
-            android:id="@+id/progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:orientation="vertical"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/header_error_tv"
+                style="@style/WizardHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/review" />
+
+            <TextView
+                android:id="@+id/header_status_desc_tv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginRight="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:gravity="center"
+                android:textSize="16sp" />
+
+            <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingLeft="16dp"
+                android:paddingTop="16dp"
+                android:paddingRight="16dp"
+                android:scrollbarStyle="outsideOverlay">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/address_home_label_tv"
+                        style="@style/WizardFormLabel"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/home_address" />
+
+                    <TextView
+                        android:id="@+id/address_home_tv_1"
+                        style="@style/WizardFormTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
+                    <TextView
+                        android:id="@+id/address_home_tv_2"
+                        style="@style/WizardFormTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
+                    <LinearLayout
+                        android:id="@+id/work_address_data"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:visibility="gone">
+
+                        <TextView
+                            android:id="@+id/work_address_label_tv"
+                            style="@style/WizardFormLabel"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/work_address" />
+
+                        <TextView
+                            android:id="@+id/work_address_tv_1"
+                            style="@style/WizardFormTextView"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content" />
+
+                        <TextView
+                            android:id="@+id/work_address_tv_2"
+                            style="@style/WizardFormTextView"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/school_address_data"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:visibility="gone">
+
+                        <TextView
+                            android:id="@+id/school_address_label_tv"
+                            style="@style/WizardFormLabel"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/school_address" />
+
+                        <TextView
+                            android:id="@+id/school_address_tv_1"
+                            style="@style/WizardFormTextView"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content" />
+
+                        <TextView
+                            android:id="@+id/school_address_tv_2"
+                            style="@style/WizardFormTextView"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
+
+                    <TextView
+                        style="@style/WizardFormLabel"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/name" />
+
+                    <TextView
+                        android:id="@+id/name_tv"
+                        style="@style/WizardFormTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
+                    <TextView
+                        android:id="@+id/email_label_tv"
+                        style="@style/WizardFormLabel"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/email" />
+
+                    <TextView
+                        android:id="@+id/email_tv"
+                        style="@style/WizardFormTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
+                    <TextView
+                        style="@style/WizardFormLabel"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/username" />
+
+                    <TextView
+                        android:id="@+id/username_tv"
+                        style="@style/WizardFormTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
+                    <TextView
+                        style="@style/WizardFormLabel"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/password" />
+
+                    <TextView
+                        android:id="@+id/pin_tv"
+                        style="@style/WizardFormTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
+                </LinearLayout>
+            </ScrollView>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/nav_buttons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/prev_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/previous"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/next_btn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_weight="1"
+                android:text="@string/create_card"
+                android:textAllCaps="true" />
+
+        </LinearLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/loading"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/trans_white"
+            android:clickable="true"
+            android:visibility="gone"
+            tools:ignore="KeyboardInaccessibleWidget">
+
+            <TextView
+                android:id="@+id/loading_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:fontFamily="sans-serif"
+                android:text="@string/creating_card"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toTopOf="@id/progress"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <ProgressBar
+                android:id="@+id/progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/main/res/layout/loading.xml
+++ b/simplified-cardcreator/src/main/res/layout/loading.xml
@@ -1,31 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/cl_loading"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/trans_white"
-    android:visibility="gone">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:fontFamily="sans-serif"
-        android:textSize="16sp"
-        app:layout_constraintBottom_toTopOf="@id/progress"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        tools:text="Loading" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_loading"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/trans_white"
+        android:visibility="gone">
 
-    <ProgressBar
-        android:id="@+id/progress"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:fontFamily="sans-serif"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toTopOf="@id/progress"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:text="Loading" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <ProgressBar
+            android:id="@+id/progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/simplified-cardcreator/src/test/kotlin/org/nypl/simplified/cardcreator/ui/ConfirmationFragmentTest.kt
+++ b/simplified-cardcreator/src/test/kotlin/org/nypl/simplified/cardcreator/ui/ConfirmationFragmentTest.kt
@@ -52,8 +52,8 @@ class ConfirmationFragmentTest {
     onView(withId(R.id.card_pin)).check(matches(withText("Password: testPassword")))
     onView(withId(R.id.header_status_desc_tv)).check(matches(withText("testMessage")))
 
-    //set up time stub
-    //onView(withId(R.id.header_status_desc_tv)).check(matches(withText("testTime")))
+    // set up time stub
+    // onView(withId(R.id.header_status_desc_tv)).check(matches(withText("testTime")))
   }
 
   @Test
@@ -124,6 +124,3 @@ fun <F : Fragment> FragmentScenario<F>.setActivityIntent(customIntent: Intent) {
     }
   }
 }
-
-
-

--- a/simplified-cardcreator/src/test/kotlin/org/nypl/simplified/cardcreator/ui/ConfirmationFragmentTest.kt
+++ b/simplified-cardcreator/src/test/kotlin/org/nypl/simplified/cardcreator/ui/ConfirmationFragmentTest.kt
@@ -1,0 +1,129 @@
+package org.nypl.simplified.cardcreator.ui
+
+import android.app.Instrumentation
+import android.content.Intent
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.EqMatcher
+import io.mockk.mockkConstructor
+import io.mockk.verify
+import org.amshove.kluent.fail
+import org.amshove.kluent.shouldBe
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.nypl.simplified.cardcreator.CardCreatorActivity
+import org.nypl.simplified.cardcreator.R
+import org.nypl.simplified.cardcreator.utils.Cache
+
+@RunWith(AndroidJUnit4::class)
+class ConfirmationFragmentTest {
+  private lateinit var scenario: FragmentScenario<ConfirmationFragment>
+
+  @Before
+  fun setUp() {
+    mockkConstructor(Cache::class)
+
+    scenario = launchFragmentInContainer(
+      fragmentArgs = bundleOf(
+        "username" to "testUser",
+        "barcode" to "testBarcode",
+        "password" to "testPassword",
+        "message" to "testMessage",
+        "name" to "testName"
+      ),
+    )
+  }
+
+  @Test
+  fun `onViewCreated correctly displays fragment args in card info`() {
+    onView(withId(R.id.name_card)).check(matches(withText("testName")))
+    onView(withId(R.id.card_barcode)).check(matches(withText("Card Number: testBarcode")))
+    onView(withId(R.id.card_pin)).check(matches(withText("Password: testPassword")))
+    onView(withId(R.id.header_status_desc_tv)).check(matches(withText("testMessage")))
+
+    //set up time stub
+    //onView(withId(R.id.header_status_desc_tv)).check(matches(withText("testTime")))
+  }
+
+  @Test
+  fun `next button sets CardCreated activity result`() {
+    onView(withId(R.id.next_btn)).perform(ViewActions.click())
+
+    scenario.getActivityResult()?.resultCode shouldBe CardCreatorActivity.CARD_CREATED
+
+    scenario.getActivityResult()?.resultData?.extras?.run {
+      getString("barcode") shouldBe "testBarcode"
+      getString("pin") shouldBe "testPassword"
+
+      getString("username") shouldBe "testUser"
+      getString("message") shouldBe "testMessage"
+    } ?: fail("Missing result data or extras")
+  }
+
+  @Test
+  fun `next button sets ChildCardCreated activity result when user is already logged in`() {
+    val loggedInIntent = Intent().apply { putExtra("isLoggedIn", true) }
+    scenario.setActivityIntent(loggedInIntent)
+
+    onView(withId(R.id.next_btn)).perform(ViewActions.click())
+
+    scenario.getActivityResult()?.resultCode shouldBe CardCreatorActivity.CHILD_CARD_CREATED
+  }
+
+  @Test
+  fun `next button clears cache and finishes activity`() {
+    onView(withId(R.id.next_btn)).perform(ViewActions.click())
+
+    scenario.onFragment {
+      it.activity?.isFinishing shouldBe true
+
+      verify {
+        constructedWith<Cache>(EqMatcher(it.requireContext())).clear()
+      }
+    }
+  }
+
+  @Ignore
+  @Test
+  fun `prev button (save Card) requests external storage permissions`() {
+    TODO("Not yet implemented")
+  }
+
+  @Ignore
+  @Test
+  fun `prev button (save Card) writes card image to device`() {
+    TODO("Not yet implemented")
+  }
+}
+
+// Marginally better than launching our own activityScenario? Maybe...
+fun <F : Fragment> FragmentScenario<F>.getActivityResult(): Instrumentation.ActivityResult? {
+  return javaClass.getDeclaredField("activityScenario").let {
+    it.isAccessible = true
+    return@let (it.get(this) as ActivityScenario<*>).result
+  }
+}
+
+// Marginally better than launching our own activityScenario? Maybe...
+fun <F : Fragment> FragmentScenario<F>.setActivityIntent(customIntent: Intent) {
+  javaClass.getDeclaredField("activityScenario").let {
+    it.isAccessible = true
+    (it.get(this) as ActivityScenario<*>).onActivity { activity ->
+      activity.intent = customIntent
+    }
+  }
+}
+
+
+

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -127,7 +127,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
 
   companion object {
 
-    private const val PARAMETERS_ID =
+    internal const val PARAMETERS_ID =
       "org.nypl.simplified.ui.accounts.AccountFragment.parameters"
 
     /**
@@ -938,14 +938,20 @@ class AccountDetailFragment : Fragment(R.layout.account) {
 
   private fun onCardCreatorResult(result: CardCreatorContract.Output?) {
     if (result == null) {
-      this.logger.debug("User has exited the card creator")
+      logger.debug("User has exited the card creator")
       return
     }
 
-    this.authenticationViews.setBasicUserAndPass(
-      user = result.barcode,
-      password = result.pin
-    )
-    this.tryLogin()
+    when (result) {
+      is CardCreatorContract.Output.CardCreated -> {
+        authenticationViews.setBasicUserAndPass(
+          user = result.barcode,
+          password = result.pin
+        )
+        tryLogin()
+      }
+      CardCreatorContract.Output.CardCreationNoOp -> logger.debug("Card creator cancellation or error")
+      CardCreatorContract.Output.ChildCardCreated -> logger.debug("Child card created")
+    }
   }
 }

--- a/simplified-ui-accounts/src/test/kotlin/org/nypl/simplified/ui/accounts/AccountDetailFragmentTest.kt
+++ b/simplified-ui-accounts/src/test/kotlin/org/nypl/simplified/ui/accounts/AccountDetailFragmentTest.kt
@@ -131,10 +131,12 @@ class AccountDetailFragmentTest {
 
     // covers initial reconfigureAccountUI state
     every { mockAccountDetailViewModel.account.loginState } returns
-      AccountLoginState.AccountLoggedIn(mockk<AccountAuthenticationCredentials.Basic> {
-        every { userName.value } returns "userName"
-        every { password.value } returns "password"
-      })
+      AccountLoginState.AccountLoggedIn(
+        mockk<AccountAuthenticationCredentials.Basic> {
+          every { userName.value } returns "userName"
+          every { password.value } returns "password"
+        }
+      )
 
     testProviderBasicAuthDescription = AccountProviderAuthenticationDescription.Basic(
       "description",

--- a/simplified-ui-accounts/src/test/kotlin/org/nypl/simplified/ui/accounts/AccountDetailFragmentTest.kt
+++ b/simplified-ui-accounts/src/test/kotlin/org/nypl/simplified/ui/accounts/AccountDetailFragmentTest.kt
@@ -1,0 +1,269 @@
+package org.nypl.simplified.ui.accounts
+
+import android.app.Instrumentation
+import android.content.Intent
+import androidx.core.os.bundleOf
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.MutableLiveData
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.hamcrest.Matchers.allOf
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.librarysimplified.services.api.Services
+import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
+import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.accounts.api.AccountLoginState
+import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription
+import org.nypl.simplified.accounts.database.api.AccountType
+import org.nypl.simplified.cardcreator.CardCreatorActivity
+import org.nypl.simplified.cardcreator.CardCreatorContract
+import org.nypl.simplified.cardcreator.CardCreatorServiceType
+import org.nypl.simplified.listeners.api.FragmentListenerFinder
+import org.nypl.simplified.listeners.api.FragmentListenerType
+import org.nypl.simplified.profiles.controller.api.ProfileAccountLoginRequest
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableStatus
+import org.nypl.simplified.ui.images.ImageAccountIcons
+import org.nypl.simplified.ui.images.ImageLoaderType
+import java.net.URI
+
+@RunWith(AndroidJUnit4::class)
+class AccountDetailFragmentTest {
+
+  private lateinit var scenario: FragmentScenario<AccountDetailFragment>
+
+  @MockK
+  private lateinit var mockAccountDetailViewModel: AccountDetailViewModel
+
+  @MockK
+  private lateinit var mockAccountDetailEventListener: FragmentListenerType<AccountDetailEvent>
+
+  private var testAccountLiveData = MutableLiveData<AccountType>()
+  private var testAccountSyncingLiveData = MutableLiveData<ReaderBookmarkSyncEnableStatus>()
+  private lateinit var testProviderBasicAuthDescription: AccountProviderAuthenticationDescription.Basic
+
+  @Before
+  fun setUp() {
+    MockKAnnotations.init(this)
+    Intents.init()
+
+    val testCardCreatorContract = CardCreatorContract(
+      "testUsername",
+      "testPassword",
+      "testClientId",
+      "testClientSecret"
+    )
+
+    mockkObject(Services)
+    every {
+      Services.serviceDirectory()
+        .optionalService(CardCreatorServiceType::class.java)!!
+        .getCardCreatorContract()
+    } returns testCardCreatorContract
+
+    every {
+      Services.serviceDirectory().requireService(ImageLoaderType::class.java)
+    } returns mockk(relaxed = true)
+
+    // Mock image loading - skip for now
+    // We need to use static mock here because of @JvmStatic annotation
+    // mockkObject(ImageAccountIcons)
+    mockkStatic(ImageAccountIcons::class)
+    every { ImageAccountIcons.loadAccountLogoIntoView(any(), any(), any(), any()) } just runs
+
+    mockkObject(FragmentListenerFinder)
+    every {
+      FragmentListenerFinder.findListener(any(), AccountDetailEvent::class.java)
+    } returns mockAccountDetailEventListener
+
+    // Mock ViewModel creation
+    mockkConstructor(AccountDetailViewModelFactory::class)
+    every {
+      anyConstructed<AccountDetailViewModelFactory>().create(AccountDetailViewModel::class.java)
+    } returns mockAccountDetailViewModel
+
+    // Emit value to trigger reconfigureAccountUI() - but we don't use the value so a mock suffices
+    every { mockAccountDetailViewModel.accountLive } returns testAccountLiveData
+    every { mockAccountDetailViewModel.accountSyncingSwitchStatus } returns testAccountSyncingLiveData
+    testAccountLiveData.value = mockk()
+
+    // covers authenticationAlternativesMake() (onViewCreated)
+    every { mockAccountDetailViewModel.account.provider.authenticationAlternatives } returns emptyList()
+    // covers ImageAccountIcons.loadAccountLogoIntoView(...)
+    every { mockAccountDetailViewModel.account.provider.toDescription() } returns mockk()
+    // covers configureToolbar (onStart)
+    every { mockAccountDetailViewModel.account.provider.displayName } returns "displayName"
+    // covers authenticationViews.setCOPPAState(...)
+    every { mockAccountDetailViewModel.isOver13 } returns true
+    // covers configureReportIssue() (onStart)
+    every { mockAccountDetailViewModel.account.provider.supportEmail } returns "supportEmail"
+
+    val uriWithNYPLScheme = URI.create("nypl.card-creator://some-address")
+    every { mockAccountDetailViewModel.account.provider.cardCreatorURI } returns uriWithNYPLScheme
+
+    // covers initial reconfigureAccountUI state
+    every { mockAccountDetailViewModel.account.loginState } returns
+      AccountLoginState.AccountLoggedIn(mockk<AccountAuthenticationCredentials.Basic> {
+        every { userName.value } returns "userName"
+        every { password.value } returns "password"
+      })
+
+    testProviderBasicAuthDescription = AccountProviderAuthenticationDescription.Basic(
+      "description",
+      "BARCODEFORMAT",
+      keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+      passwordMaximumLength = 10,
+      passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+      emptyMap(),
+      URI.create("logoURI")
+    )
+    every { mockAccountDetailViewModel.account.provider.authentication } returns testProviderBasicAuthDescription
+    every { mockAccountDetailViewModel.account.provider.subtitle } returns "subtitle"
+    every { mockAccountDetailViewModel.account.preferences.catalogURIOverride } returns null
+
+    val accountDetailArguments = AccountFragmentParameters(
+      accountId = AccountID.generate(),
+      closeOnLoginSuccess = false,
+      showPleaseLogInTitle = false
+    )
+    scenario = launchFragmentInContainer(
+      fragmentArgs = bundleOf(AccountDetailFragment.PARAMETERS_ID to accountDetailArguments),
+      themeResId = R.style.SimplifiedTheme_ActionBar
+    )
+  }
+
+  @After
+  fun tearDown() {
+    Intents.release()
+  }
+
+  @Test
+  fun `sign up button opens card creator activity when account provider cardCreatorURI is NYPL`() {
+    onView(withId(R.id.accountCardCreatorSignUp)).check(matches(isEnabled()))
+    onView(withId(R.id.accountCardCreatorSignUp)).perform(click())
+
+    // We're kind of testing CardCreatorContract implicitly here as well...probably okay?
+    // allOf(...) failure doesn't provide great feedback as to which condition was missed...
+    intended(
+      allOf(
+        hasComponent(CardCreatorActivity::class.java.name),
+        hasExtra("isLoggedIn", true),
+        hasExtra("userIdentifier", "userName")
+      )
+    )
+  }
+
+  @Test
+  fun `sign up button opens web card creator when account provider cardCreatorURI is not NYPL`() {
+    every { mockAccountDetailViewModel.account.provider.cardCreatorURI } returns
+      URI.create("non-nypl-cardCreatorUri")
+
+    onView(withId(R.id.accountCardCreatorSignUp)).check(matches(isEnabled()))
+    onView(withId(R.id.accountCardCreatorSignUp)).perform(click())
+
+    intended(
+      allOf(
+        hasAction(Intent.ACTION_VIEW),
+        hasData("non-nypl-cardCreatorUri")
+      )
+    )
+  }
+
+  @Test
+  fun `on card creator result tries to do basicAuth login when card is newly created`() {
+    val requestSlot = slot<ProfileAccountLoginRequest.Basic>()
+    justRun { mockAccountDetailViewModel.tryLogin(capture(requestSlot)) }
+
+    val testAccountID = AccountID.generate()
+    every { mockAccountDetailViewModel.account.id } returns testAccountID
+
+    val resultData = Intent().apply {
+      putExtra("barcode", "testBarcode")
+      putExtra("pin", "testPin")
+    }
+    val stubbedResult = Instrumentation.ActivityResult(CardCreatorActivity.CARD_CREATED, resultData)
+
+    intending(hasComponent(CardCreatorActivity::class.java.name))
+      .respondWith(stubbedResult)
+
+    onView(withId(R.id.accountCardCreatorSignUp)).perform(click())
+
+    requestSlot.isCaptured shouldBe true
+    requestSlot.captured.apply {
+      accountId shouldBe testAccountID
+      description shouldBe testProviderBasicAuthDescription
+      username.value shouldBeEqualTo "testBarcode"
+      password.value shouldBeEqualTo "testPin"
+    }
+  }
+
+  @Test
+  fun `on card creator result does not attempt sign in when child card is created`() {
+    val emptyIntent = Intent()
+    val stubbedResult =
+      Instrumentation.ActivityResult(CardCreatorActivity.CHILD_CARD_CREATED, emptyIntent)
+
+    intending(hasComponent(CardCreatorActivity::class.java.name))
+      .respondWith(stubbedResult)
+
+    onView(withId(R.id.accountCardCreatorSignUp)).perform(click())
+
+    verify(exactly = 0) { mockAccountDetailViewModel.tryLogin(any()) }
+  }
+
+  @Test
+  fun `on card creator result does not attempt sign in when activity finishes with error`() {
+    val emptyIntent = Intent()
+    val stubbedResult =
+      Instrumentation.ActivityResult(CardCreatorActivity.CARD_CREATION_ERROR, emptyIntent)
+
+    intending(hasComponent(CardCreatorActivity::class.java.name))
+      .respondWith(stubbedResult)
+
+    onView(withId(R.id.accountCardCreatorSignUp)).perform(click())
+
+    verify(exactly = 0) { mockAccountDetailViewModel.tryLogin(any()) }
+  }
+
+  @Test
+  fun `on card creator result does not attempt sign in when activity is cancelled`() {
+    val emptyIntent = Intent()
+    val stubbedResult =
+      Instrumentation.ActivityResult(CardCreatorActivity.CARD_CREATION_CANCELED, emptyIntent)
+
+    intending(hasComponent(CardCreatorActivity::class.java.name))
+      .respondWith(stubbedResult)
+
+    onView(withId(R.id.accountCardCreatorSignUp)).perform(click())
+
+    verify(exactly = 0) { mockAccountDetailViewModel.tryLogin(any()) }
+  }
+}


### PR DESCRIPTION
**WIP**

**What's this do?**
- Convert viewBinding to dataBinding for the card-creator module
- Add espresso-intents for testing activity results and result callbacks
- Prevent app from attempting to log in again when the card creator is exited, errors, or creates a child card

I converted everything to databinding but haven't refactored anything to use it yet.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SMA-307
https://jira.nypl.org/browse/SMA-325
https://jira.nypl.org/browse/SMA-331

There are several bugs around accidental logouts happening when moving out of the card creator process.

**How should this be tested? / Do these changes have associated tests?**
There are isolated fragment tests for the AccountDetailFragment and ConfirmationFragment

**Dependencies for merging? Releasing to production?**
Eventually will need a platform update for adding espresso-intents

**Has the application documentation been updated for these changes?**
No documentation changes needed

**Did someone actually run this code to verify it works?**
Tested on my Pixel 2 device - app no longer logs people out when a child card is created, an error is received during child card creation, or when the user navigates back out of the card creator
