### PR TITLE
SMA-355: revisit findaway player

### DIFF
--- a/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookManifestStrategy.kt
+++ b/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookManifestStrategy.kt
@@ -1,6 +1,8 @@
 package org.nypl.simplified.books.audio
 
 import com.io7m.junreachable.UnimplementedCodeException
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
 import one.irradia.mime.api.MIMEType
 import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.license_check.api.LicenseCheckParameters
@@ -28,8 +30,6 @@ import org.nypl.simplified.taskrecorder.api.TaskRecorder
 import org.nypl.simplified.taskrecorder.api.TaskRecorderType
 import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.slf4j.LoggerFactory
-import rx.Observable
-import rx.subjects.PublishSubject
 import java.net.URI
 
 /**
@@ -275,7 +275,7 @@ class AudioBookManifestStrategy(
     try {
       return strategy.execute()
     } finally {
-      fulfillSubscription.unsubscribe()
+      fulfillSubscription.dispose()
     }
   }
 
@@ -403,7 +403,7 @@ class AudioBookManifestStrategy(
     try {
       return check.execute()
     } finally {
-      checkSubscription.unsubscribe()
+      checkSubscription.dispose()
     }
   }
 

--- a/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookManifestStrategyType.kt
+++ b/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookManifestStrategyType.kt
@@ -1,7 +1,7 @@
 package org.nypl.simplified.books.audio
 
+import io.reactivex.Observable
 import org.nypl.simplified.taskrecorder.api.TaskResult
-import rx.Observable
 
 /**
  * A strategy for downloading, parsing, and license-checking an audio book manifest. A given

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowAudioBook.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowAudioBook.kt
@@ -8,7 +8,9 @@ import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
 import org.nypl.simplified.accounts.api.AccountReadableType
 import org.nypl.simplified.books.audio.AudioBookCredentials
 import org.nypl.simplified.books.audio.AudioBookManifestRequest
-import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle
+import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleAudioBook
+import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleEPUB
+import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandlePDF
 import org.nypl.simplified.books.borrowing.BorrowContextType
 import org.nypl.simplified.books.borrowing.internal.BorrowErrorCodes.audioStrategyFailed
 import org.nypl.simplified.books.borrowing.subtasks.BorrowSubtaskException.BorrowSubtaskFailed
@@ -165,15 +167,15 @@ class BorrowAudioBook private constructor() : BorrowSubtaskType {
     context.taskRecorder.beginNewStep("Saving book...")
 
     return when (val formatHandle = context.bookDatabaseEntry.findFormatHandleForContentType(context.currentAcquisitionPathElement.mimeType)) {
-      is BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleAudioBook -> {
+      is BookDatabaseEntryFormatHandleAudioBook -> {
         formatHandle.copyInManifestAndURI(
           data = data.file.readBytes(),
           manifestURI = data.sourceURI
         )
         context.bookDownloadSucceeded()
       }
-      is BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandlePDF,
-      is BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleEPUB,
+      is BookDatabaseEntryFormatHandlePDF,
+      is BookDatabaseEntryFormatHandleEPUB,
       null ->
         throw UnreachableCodeException()
     }

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowAudioBook.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowAudioBook.kt
@@ -8,9 +8,7 @@ import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
 import org.nypl.simplified.accounts.api.AccountReadableType
 import org.nypl.simplified.books.audio.AudioBookCredentials
 import org.nypl.simplified.books.audio.AudioBookManifestRequest
-import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleAudioBook
-import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleEPUB
-import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandlePDF
+import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.*
 import org.nypl.simplified.books.borrowing.BorrowContextType
 import org.nypl.simplified.books.borrowing.internal.BorrowErrorCodes.audioStrategyFailed
 import org.nypl.simplified.books.borrowing.subtasks.BorrowSubtaskException.BorrowSubtaskFailed
@@ -156,7 +154,7 @@ class BorrowAudioBook private constructor() : BorrowSubtaskType {
         }
       }
     } finally {
-      subscription.unsubscribe()
+      subscription.dispose()
     }
   }
 

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowAudioBook.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowAudioBook.kt
@@ -8,7 +8,7 @@ import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
 import org.nypl.simplified.accounts.api.AccountReadableType
 import org.nypl.simplified.books.audio.AudioBookCredentials
 import org.nypl.simplified.books.audio.AudioBookManifestRequest
-import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.*
+import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle
 import org.nypl.simplified.books.borrowing.BorrowContextType
 import org.nypl.simplified.books.borrowing.internal.BorrowErrorCodes.audioStrategyFailed
 import org.nypl.simplified.books.borrowing.subtasks.BorrowSubtaskException.BorrowSubtaskFailed
@@ -165,15 +165,15 @@ class BorrowAudioBook private constructor() : BorrowSubtaskType {
     context.taskRecorder.beginNewStep("Saving book...")
 
     return when (val formatHandle = context.bookDatabaseEntry.findFormatHandleForContentType(context.currentAcquisitionPathElement.mimeType)) {
-      is BookDatabaseEntryFormatHandleAudioBook -> {
+      is BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleAudioBook -> {
         formatHandle.copyInManifestAndURI(
           data = data.file.readBytes(),
           manifestURI = data.sourceURI
         )
         context.bookDownloadSucceeded()
       }
-      is BookDatabaseEntryFormatHandlePDF,
-      is BookDatabaseEntryFormatHandleEPUB,
+      is BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandlePDF,
+      is BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleEPUB,
       null ->
         throw UnreachableCodeException()
     }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockAudioBookManifestStrategy.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockAudioBookManifestStrategy.kt
@@ -1,10 +1,10 @@
 package org.nypl.simplified.tests.mocking
 
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
 import org.nypl.simplified.books.audio.AudioBookManifestData
 import org.nypl.simplified.books.audio.AudioBookManifestStrategyType
 import org.nypl.simplified.taskrecorder.api.TaskResult
-import rx.Observable
-import rx.subjects.PublishSubject
 
 class MockAudioBookManifestStrategy : AudioBookManifestStrategyType {
 

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookLoadingFragment.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookLoadingFragment.kt
@@ -43,7 +43,6 @@ class AudioBookLoadingFragment : Fragment() {
 
   private lateinit var ioExecutor: ListeningExecutorService
   private lateinit var listener: AudioBookLoadingFragmentListenerType
-  private lateinit var loadingParameters: AudioBookLoadingFragmentParameters
   private lateinit var playerParameters: AudioBookPlayerParameters
   private lateinit var profiles: ProfilesControllerType
   private lateinit var progress: ProgressBar
@@ -71,10 +70,6 @@ class AudioBookLoadingFragment : Fragment() {
     this.log.debug("onCreate")
 
     super.onCreate(state)
-
-    this.loadingParameters =
-      this.arguments!!.getSerializable(parametersKey)
-      as AudioBookLoadingFragmentParameters
 
     val services = Services.serviceDirectory()
 

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -10,16 +10,37 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.google.common.util.concurrent.MoreExecutors
 import io.reactivex.disposables.Disposable
-import org.librarysimplified.audiobook.api.*
+import org.librarysimplified.audiobook.api.PlayerAudioBookType
+import org.librarysimplified.audiobook.api.PlayerAudioEngineRequest
+import org.librarysimplified.audiobook.api.PlayerAudioEngines
+import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
+import org.librarysimplified.audiobook.api.PlayerEvent
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventError
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventPlaybackRateChanged
-import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.*
+import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventChapterCompleted
+import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventChapterWaiting
+import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackBuffering
+import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackPaused
+import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate
+import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted
+import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStopped
+import org.librarysimplified.audiobook.api.PlayerPosition
+import org.librarysimplified.audiobook.api.PlayerResult
+import org.librarysimplified.audiobook.api.PlayerSleepTimer
+import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadExpired
+import org.librarysimplified.audiobook.api.PlayerType
+import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.api.extensions.PlayerExtensionType
 import org.librarysimplified.audiobook.downloads.DownloadProvider
 import org.librarysimplified.audiobook.feedbooks.FeedbooksPlayerExtension
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
-import org.librarysimplified.audiobook.views.*
+import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent
+import org.librarysimplified.audiobook.views.PlayerFragment
+import org.librarysimplified.audiobook.views.PlayerFragmentListenerType
+import org.librarysimplified.audiobook.views.PlayerPlaybackRateFragment
+import org.librarysimplified.audiobook.views.PlayerSleepTimerFragment
+import org.librarysimplified.audiobook.views.PlayerTOCFragment
 import org.librarysimplified.http.api.LSHTTPClientType
 import org.librarysimplified.services.api.ServiceDirectoryType
 import org.librarysimplified.services.api.Services
@@ -132,6 +153,7 @@ class AudioBookPlayerActivity :
       playerScheduledExecutor,
       sleepTimer
     )
+    supportFragmentManager.fragmentFactory = fragmentFactory
 
     super.onCreate(null)
 

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudiobookFragmentFactory.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudiobookFragmentFactory.kt
@@ -28,7 +28,7 @@ class AudiobookFragmentFactory(
       PlayerPlaybackRateFragment::class.java.name ->
         PlayerPlaybackRateFragment(listener, player)
       PlayerSleepTimerFragment::class.java.name ->
-        PlayerSleepTimerFragment(listener, sleepTimer)
+        PlayerSleepTimerFragment(listener, player, sleepTimer)
       PlayerTOCFragment::class.java.name ->
         PlayerTOCFragment(listener, book, player)
       else -> super.instantiate(classLoader, className)

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudiobookFragmentFactory.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudiobookFragmentFactory.kt
@@ -13,8 +13,8 @@ import org.librarysimplified.audiobook.views.PlayerTOCFragment
 import java.util.concurrent.ScheduledExecutorService
 
 class AudiobookFragmentFactory(
-  private val playerDelegate: Lazy<PlayerType>,
-  private val bookDelegate: Lazy<PlayerAudioBookType>,
+  private val player: PlayerType,
+  private val book: PlayerAudioBookType,
   private val listener: PlayerFragmentListenerType,
   private val scheduledExecutorService: ScheduledExecutorService,
   private val sleepTimer: PlayerSleepTimerType
@@ -22,14 +22,15 @@ class AudiobookFragmentFactory(
   override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
     return when (className) {
       AudioBookLoadingFragment::class.java.name -> AudioBookLoadingFragment()
-      PlayerFragment::class.java.name ->
-        PlayerFragment(listener, playerDelegate.value, bookDelegate.value, scheduledExecutorService, sleepTimer)
+      PlayerFragment::class.java.name -> {
+        PlayerFragment(listener, player, book, scheduledExecutorService, sleepTimer)
+      }
       PlayerPlaybackRateFragment::class.java.name ->
-        PlayerPlaybackRateFragment(listener, playerDelegate.value)
+        PlayerPlaybackRateFragment(listener, player)
       PlayerSleepTimerFragment::class.java.name ->
-        PlayerSleepTimerFragment(listener, playerDelegate.value, sleepTimer)
+        PlayerSleepTimerFragment(listener, sleepTimer)
       PlayerTOCFragment::class.java.name ->
-        PlayerTOCFragment(listener, bookDelegate.value, playerDelegate.value)
+        PlayerTOCFragment(listener, book, player)
       else -> super.instantiate(classLoader, className)
     }
   }

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudiobookFragmentFactory.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudiobookFragmentFactory.kt
@@ -5,7 +5,11 @@ import androidx.fragment.app.FragmentFactory
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerType
-import org.librarysimplified.audiobook.views.*
+import org.librarysimplified.audiobook.views.PlayerFragment
+import org.librarysimplified.audiobook.views.PlayerFragmentListenerType
+import org.librarysimplified.audiobook.views.PlayerPlaybackRateFragment
+import org.librarysimplified.audiobook.views.PlayerSleepTimerFragment
+import org.librarysimplified.audiobook.views.PlayerTOCFragment
 import java.util.concurrent.ScheduledExecutorService
 
 class AudiobookFragmentFactory(

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudiobookFragmentFactory.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudiobookFragmentFactory.kt
@@ -1,0 +1,32 @@
+package org.nypl.simplified.viewer.audiobook
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import org.librarysimplified.audiobook.api.PlayerAudioBookType
+import org.librarysimplified.audiobook.api.PlayerSleepTimerType
+import org.librarysimplified.audiobook.api.PlayerType
+import org.librarysimplified.audiobook.views.*
+import java.util.concurrent.ScheduledExecutorService
+
+class AudiobookFragmentFactory(
+  private val playerDelegate: Lazy<PlayerType>,
+  private val bookDelegate: Lazy<PlayerAudioBookType>,
+  private val listener: PlayerFragmentListenerType,
+  private val scheduledExecutorService: ScheduledExecutorService,
+  private val sleepTimer: PlayerSleepTimerType
+) : FragmentFactory() {
+  override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+    return when (className) {
+      AudioBookLoadingFragment::class.java.name -> AudioBookLoadingFragment()
+      PlayerFragment::class.java.name ->
+        PlayerFragment(listener, playerDelegate.value, bookDelegate.value, scheduledExecutorService, sleepTimer)
+      PlayerPlaybackRateFragment::class.java.name ->
+        PlayerPlaybackRateFragment(listener, playerDelegate.value)
+      PlayerSleepTimerFragment::class.java.name ->
+        PlayerSleepTimerFragment(listener, playerDelegate.value, sleepTimer)
+      PlayerTOCFragment::class.java.name ->
+        PlayerTOCFragment(listener, bookDelegate.value, playerDelegate.value)
+      else -> super.instantiate(classLoader, className)
+    }
+  }
+}


### PR DESCRIPTION
**What's this do?**
This PR updates Core to use the latest release of audiobook-android and audioengine-android, and makes a few changes necessary to do so, such as using a FragmentFactory for the AudiobookActivity's fragment creation.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SMA-355

**How should this be tested? / Do these changes have associated tests?**
No directly associated tests for these changes. To test, just opening the app and bouncing around a few audiobooks should be sufficient.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No documentation changes needed

**Did someone actually run this code to verify it works?**
I tested a few audiobooks on my Pixel 5a device
