### PR TITLE
Remove unused card creator base URLs

### DIFF
--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/Constants.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/Constants.kt
@@ -4,9 +4,6 @@ package org.nypl.simplified.cardcreator.utils
  * Base URLs used with Library Simplified endpoints
  */
 object Constants {
-  const val LIBRARY_SIMPLIFIED_BASE_URL = "http://patrons.librarysimplified.org/"
-  const val LIBRARY_SIMPLIFIED_QA_BASE_URL = "http://qa.patrons.librarysimplified.org/"
-
   const val EULA = "https://librarysimplified.org/EULA/"
   const val LEGAL_DISCLAIMER = "https://www.nypl.org/help/library-card/terms-conditions"
 


### PR DESCRIPTION
**What's this do?**
There are some old base URLs in the project that are not used, now they have been removed. Testing was done with @leonardr and it was confirmed that these URLs are not used.

**Why are we doing this? (w/ JIRA link if applicable)**
n/a

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
n/a
