### PR TITLE
OE-525: Re-add Clever to the login flow of Open eBooks

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -383,7 +383,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
 
   private fun instantiateAlternativeAuthenticationViews() {
     for (alternative in this.viewModel.account.provider.authenticationAlternatives) {
-      return when (alternative) {
+      when (alternative) {
         is AccountProviderAuthenticationDescription.COPPAAgeGate ->
           this.logger.warn("COPPA age gate is not currently supported as an alternative.")
         is AccountProviderAuthenticationDescription.Basic ->


### PR DESCRIPTION
**What's this do?**
Fixes the missing Clever login button from the AccountDetails page for openEbooks. A 'return' was added to the for-loop that dynamically populates the alternative auth views, which bails out of the parent function (not just the for-loop), preventing the app from properly iterating over and potentially creating views for each auth alternative. 

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-525

**How should this be tested? / Do these changes have associated tests?**
Open up the Accounts page in OpenEbooks and observe the return of the "Log in with Clever" button

**Dependencies for merging? Releasing to production?**
No dependency changes

**Has the application documentation been updated for these changes?**
No documentation changes

**Did someone actually run this code to verify it works?**
Tested locally on my Pixel 5a device
