### PR TITLE
OE-526: Add Swipe-To-Refresh to Catalog

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -160,10 +160,9 @@ class CatalogFeedFragment : Fragment(), AgeGateDialog.BirthYearSelectedListener 
 
     val withGroupsSwipeContainer = binding.feedWithGroups.feedWithGroupsSwipeContainer
     withGroupsSwipeContainer.setOnRefreshListener {
-      viewModel.reloadFeed()
       withGroupsSwipeContainer.isRefreshing = false
+      viewModel.reloadFeed()
     }
-    withGroupsSwipeContainer.setProgressViewEndTarget(false, 0)
 
     feedWithGroupsList.addItemDecoration(
       CatalogFeedWithGroupsDecorator(screenInformation.dpToPixels(16).toInt())
@@ -186,10 +185,9 @@ class CatalogFeedFragment : Fragment(), AgeGateDialog.BirthYearSelectedListener 
 
     val withoutGroupsSwipeContainer = binding.feedWithoutGroups.feedWithoutGroupsSwipeContainer
     withoutGroupsSwipeContainer.setOnRefreshListener {
-      viewModel.reloadFeed()
       withoutGroupsSwipeContainer.isRefreshing = false
+      viewModel.reloadFeed()
     }
-    // withoutGroupsSwipeContainer.setProgressViewEndTarget(false, 0)
 
     withoutGroupsAdapter = CatalogPagedAdapter(
       context = requireActivity(),

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -237,10 +237,6 @@ class CatalogFeedFragment : Fragment(), AgeGateDialog.BirthYearSelectedListener 
         }
         true
       }
-      R.id.catalogMenuActionReload -> {
-        viewModel.syncAccounts()
-        true
-      }
       android.R.id.home -> {
         if (viewModel.isAccountCatalogRoot()) {
           openAccountPickerDialog()

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -158,6 +158,13 @@ class CatalogFeedFragment : Fragment(), AgeGateDialog.BirthYearSelectedListener 
 
     sharedListConfiguration(feedWithGroupsList)
 
+    val withGroupsSwipeContainer = binding.feedWithGroups.feedWithGroupsSwipeContainer
+    withGroupsSwipeContainer.setOnRefreshListener {
+      viewModel.reloadFeed()
+      withGroupsSwipeContainer.isRefreshing = false
+    }
+    withGroupsSwipeContainer.setProgressViewEndTarget(false, 0)
+
     feedWithGroupsList.addItemDecoration(
       CatalogFeedWithGroupsDecorator(screenInformation.dpToPixels(16).toInt())
     )
@@ -176,6 +183,13 @@ class CatalogFeedFragment : Fragment(), AgeGateDialog.BirthYearSelectedListener 
     val feedWithoutGroupsList = binding.feedWithoutGroups.feedWithoutGroupsList
 
     sharedListConfiguration(feedWithoutGroupsList)
+
+    val withoutGroupsSwipeContainer = binding.feedWithoutGroups.feedWithoutGroupsSwipeContainer
+    withoutGroupsSwipeContainer.setOnRefreshListener {
+      viewModel.reloadFeed()
+      withoutGroupsSwipeContainer.isRefreshing = false
+    }
+    // withoutGroupsSwipeContainer.setProgressViewEndTarget(false, 0)
 
     withoutGroupsAdapter = CatalogPagedAdapter(
       context = requireActivity(),

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -30,7 +30,6 @@ import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookStatusEvent
 import org.nypl.simplified.books.book_registry.BookWithStatus
-import org.nypl.simplified.books.controller.api.BooksControllerType
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.feeds.api.Feed
 import org.nypl.simplified.feeds.api.FeedEntry

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -74,7 +74,6 @@ class CatalogFeedViewModel(
   private val resources: Resources,
   private val profilesController: ProfilesControllerType,
   private val feedLoader: FeedLoaderType,
-  private val booksController: BooksControllerType,
   private val bookRegistry: BookRegistryType,
   private val buildConfiguration: BuildConfigurationServiceType,
   private val analytics: AnalyticsType,
@@ -267,37 +266,6 @@ class CatalogFeedViewModel(
 
   val feedStateLiveData: LiveData<CatalogFeedState>
     get() = stateMutable
-
-  fun syncAccounts() {
-    when (val arguments = state.arguments) {
-      is CatalogFeedArgumentsLocalBooks -> {
-        this.syncAccounts(arguments)
-      }
-      is CatalogFeedArgumentsRemote -> {
-      }
-    }
-  }
-
-  private fun syncAccounts(arguments: CatalogFeedArgumentsLocalBooks) {
-    val profile =
-      this.profilesController.profileCurrent()
-    val accountsToSync =
-      if (arguments.filterAccount == null) {
-        // Sync all accounts
-        this.logger.debug("[{}]: syncing all accounts", this.instanceId)
-        profile.accounts()
-      } else {
-        // Sync the account we're filtering on
-        this.logger.debug("[{}]: syncing account {}", this.instanceId, arguments.filterAccount)
-        profile.accounts().filterKeys { it == arguments.filterAccount }
-      }
-
-    for (account in accountsToSync.keys) {
-      this.booksController.booksSync(account)
-    }
-
-    // Feed will be automatically reloaded if necessary in response to BookStatus change.
-  }
 
   fun reloadFeed() {
     this.loadFeed(state.arguments)

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModelFactory.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModelFactory.kt
@@ -36,8 +36,6 @@ class CatalogFeedViewModelFactory(
       modelClass.isAssignableFrom(CatalogFeedViewModel::class.java) -> {
         val feedLoader: FeedLoaderType =
           this.services.requireService(FeedLoaderType::class.java)
-        val booksController: BooksControllerType =
-          this.services.requireService(BooksControllerType::class.java)
         val profilesController: ProfilesControllerType =
           this.services.requireService(ProfilesControllerType::class.java)
         val bookRegistry =
@@ -51,7 +49,6 @@ class CatalogFeedViewModelFactory(
           this.application.resources,
           profilesController,
           feedLoader,
-          booksController,
           bookRegistry,
           buildConfig,
           analytics,

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModelFactory.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModelFactory.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModelProvider
 import org.librarysimplified.services.api.ServiceDirectoryType
 import org.nypl.simplified.analytics.api.AnalyticsType
 import org.nypl.simplified.books.book_registry.BookRegistryType
-import org.nypl.simplified.books.controller.api.BooksControllerType
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.feeds.api.FeedLoaderType
 import org.nypl.simplified.listeners.api.FragmentListenerType

--- a/simplified-ui-catalog/src/main/res/layout/feed_with_groups.xml
+++ b/simplified-ui-catalog/src/main/res/layout/feed_with_groups.xml
@@ -18,15 +18,25 @@
             android:id="@+id/feedWithGroupsHeader"
             layout="@layout/feed_header" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/feedWithGroupsList"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/feedWithGroupsSwipeContainer"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:clipChildren="false"
-            android:clipToPadding="false"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/feedWithGroupsHeader" />
+            app:layout_constraintTop_toBottomOf="@id/feedWithGroupsHeader">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/feedWithGroupsList"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:clipChildren="false"
+                android:clipToPadding="false"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/simplified-ui-catalog/src/main/res/layout/feed_without_groups.xml
+++ b/simplified-ui-catalog/src/main/res/layout/feed_without_groups.xml
@@ -20,14 +20,25 @@
             android:id="@+id/feedWithoutGroupsHeader"
             layout="@layout/feed_header" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/feedWithoutGroupsList"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/feedWithoutGroupsSwipeContainer"
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/feedWithoutGroupsHeader" />
+            app:layout_constraintTop_toBottomOf="@id/feedWithoutGroupsHeader">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/feedWithoutGroupsList"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/simplified-ui-catalog/src/main/res/menu/catalog.xml
+++ b/simplified-ui-catalog/src/main/res/menu/catalog.xml
@@ -6,9 +6,4 @@
     android:icon="@drawable/search"
     android:title="@string/catalogSearch"
     app:showAsAction="ifRoom" />
-  <item
-    android:id="@+id/catalogMenuActionReload"
-    android:icon="@drawable/refresh"
-    android:title="@string/catalogReload"
-    app:showAsAction="never" />
 </menu>

--- a/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/testUtils/SwipeToRefresh.kt
+++ b/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/testUtils/SwipeToRefresh.kt
@@ -1,0 +1,73 @@
+package org.nypl.simplified.testUtils
+
+import android.view.View
+import android.view.animation.Animation
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import io.mockk.mockk
+import org.hamcrest.BaseMatcher
+import org.hamcrest.CoreMatchers.isA
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+/*
+https://github.com/robolectric/robolectric/issues/5375
+
+Hacky way to force the onRefreshListener for a SwipeRefreshLayout to be invoked when running
+a fragment scenario test in the JVM using Robolectric
+
+ */
+
+fun robolectricSwipeToRefresh(): ViewAction {
+  return object : ViewAction {
+    override fun getConstraints(): Matcher<View>? {
+      return object : BaseMatcher<View>() {
+        override fun matches(item: Any): Boolean {
+          return isA(SwipeRefreshLayout::class.java).matches(item)
+        }
+
+        override fun describeMismatch(item: Any, mismatchDescription: Description) {
+          mismatchDescription.appendText(
+            "Expected SwipeRefreshLayout or its Descendant, but got other View"
+          )
+        }
+
+        override fun describeTo(description: Description) {
+          description.appendText(
+            "Action SwipeToRefresh to view SwipeRefreshLayout or its descendant"
+          )
+        }
+      }
+    }
+
+    override fun getDescription(): String {
+      return "Perform swipeToRefresh on the SwipeRefreshLayout"
+    }
+
+    override fun perform(uiController: UiController, view: View) {
+      val swipeRefreshLayout = view as SwipeRefreshLayout
+      swipeRefreshLayout.run {
+        isRefreshing = true
+        // set mNotify to true
+        val notify = SwipeRefreshLayout::class.memberProperties.find {
+          it.name == "mNotify"
+        }
+        notify?.isAccessible = true
+        if (notify is KMutableProperty<*>) {
+          notify.setter.call(this, true)
+        }
+        // mockk mRefreshListener onAnimationEnd
+        val refreshListener = SwipeRefreshLayout::class.memberProperties.find {
+          it.name == "mRefreshListener"
+        }
+        refreshListener?.isAccessible = true
+        val animatorListener = refreshListener?.get(this) as Animation.AnimationListener
+        animatorListener.onAnimationEnd(mockk())
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What's this do?**
This PR adds the swipe-to-refresh functionality to the Catalog page

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-526

**How should this be tested? / Do these changes have associated tests?**
Try entering any catalog or books page, and see that in both grouped and non-grouped feeds a swipe down will reload the feed.

**Dependencies for merging? Releasing to production?**
No dependencies changed

**Has the application documentation been updated for these changes?**
No documentation changed

**Did someone actually run this code to verify it works?**
Tested locally on my Pixel 5a
