### PR TITLE
OE-527: Remove EBook Format Labels

### DIFF
--- a/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
+++ b/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
@@ -20,6 +20,8 @@ class OEIBuildConfigurationService : BuildConfigurationServiceType {
     get() = false
   override val showBooksFromAllAccounts: Boolean
     get() = false
+  override val showFormatLabel: Boolean
+    get() = false
   override val supportErrorReportEmailAddress: String
     get() = "simplyemigrationreports@nypl.org"
   override val supportErrorReportSubject: String

--- a/simplified-app-simplye/src/main/java/org/nypl/simplified/simplye/SimplyEBuildConfigurationService.kt
+++ b/simplified-app-simplye/src/main/java/org/nypl/simplified/simplye/SimplyEBuildConfigurationService.kt
@@ -22,6 +22,8 @@ class SimplyEBuildConfigurationService : BuildConfigurationServiceType {
     get() = true
   override val showBooksFromAllAccounts: Boolean
     get() = false
+  override val showFormatLabel: Boolean
+    get() = true
   override val showChangeAccountsUi: Boolean
     get() = true
   override val showDebugBookDetailStatus: Boolean

--- a/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
+++ b/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
@@ -24,6 +24,8 @@ class VanillaBuildConfigurationService : BuildConfigurationServiceType {
     get() = true
   override val showBooksFromAllAccounts: Boolean
     get() = true
+  override val showFormatLabel: Boolean
+    get() = true
   override val vcsCommit: String
     get() = BuildConfig.GIT_COMMIT
   override val simplifiedVersion: String

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationCatalogType.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationCatalogType.kt
@@ -37,6 +37,11 @@ interface BuildConfigurationCatalogType {
   val showBooksFromAllAccounts: Boolean
 
   /**
+   * Should the 'eBooks'/'audiobook'/'pdf' label be shown on book details in the catalog?
+   */
+  val showFormatLabel: Boolean
+
+  /**
    * Enable/disable returning books.
    */
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -41,7 +41,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
 
   companion object {
 
-    private const val PARAMETERS_ID =
+    const val PARAMETERS_ID =
       "org.nypl.simplified.ui.catalog.CatalogFragmentBookDetail.parameters"
 
     /**
@@ -239,15 +239,17 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     this.title.text = opds.title
     this.authors.text = opds.authorsCommaSeparated
 
-    this.format.text = when (feedEntry.probableFormat) {
-      BookFormats.BookFormatDefinition.BOOK_FORMAT_EPUB ->
-        context.getString(R.string.catalogBookFormatEPUB)
-      BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO ->
-        context.getString(R.string.catalogBookFormatAudioBook)
-      BookFormats.BookFormatDefinition.BOOK_FORMAT_PDF ->
-        context.getString(R.string.catalogBookFormatPDF)
-      null -> ""
-    }
+    if (buildConfig.showFormatLabel) {
+      this.format.text = when (feedEntry.probableFormat) {
+        BookFormats.BookFormatDefinition.BOOK_FORMAT_EPUB ->
+          context.getString(R.string.catalogBookFormatEPUB)
+        BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO ->
+          context.getString(R.string.catalogBookFormatAudioBook)
+        BookFormats.BookFormatDefinition.BOOK_FORMAT_PDF ->
+          context.getString(R.string.catalogBookFormatPDF)
+        null -> ""
+      }
+    } else format.visibility = View.GONE
 
     this.cover.contentDescription =
       CatalogBookAccessibilityStrings.coverDescription(this.resources, feedEntry)

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -182,6 +182,7 @@ class CatalogFeedFragment : Fragment(), AgeGateDialog.BirthYearSelectedListener 
       listener = viewModel,
       buttonCreator = buttonCreator,
       bookCovers = bookCoverProvider,
+      config = configService
     )
 
     feedWithoutGroupsList.adapter = withoutGroupsAdapter

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedAdapter.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.nypl.simplified.books.covers.BookCoverProviderType
+import org.nypl.simplified.buildconfig.api.BuildConfigurationCatalogType
 import org.nypl.simplified.feeds.api.FeedEntry
 import org.slf4j.LoggerFactory
 
@@ -19,6 +20,7 @@ class CatalogPagedAdapter(
   private val listener: CatalogPagedViewListener,
   private val buttonCreator: CatalogButtons,
   private val bookCovers: BookCoverProviderType,
+  private val config: BuildConfigurationCatalogType
 ) : PagedListAdapter<FeedEntry, CatalogPagedViewHolder>(CatalogPagedAdapterDiffing.comparisonCallback) {
 
   private val logger =
@@ -39,6 +41,7 @@ class CatalogPagedAdapter(
       parent = LayoutInflater.from(parent.context).inflate(R.layout.book_cell, parent, false),
       buttonCreator = this.buttonCreator,
       bookCovers = this.bookCovers,
+      config = config
     )
   }
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -18,6 +18,7 @@ import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinit
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.covers.BookCoverProviderType
+import org.nypl.simplified.buildconfig.api.BuildConfigurationCatalogType
 import org.nypl.simplified.feeds.api.FeedEntry
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryCorrupt
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryOPDS
@@ -33,6 +34,7 @@ class CatalogPagedViewHolder(
   private val parent: View,
   private val buttonCreator: CatalogButtons,
   private val bookCovers: BookCoverProviderType,
+  private val config: BuildConfigurationCatalogType
 ) : RecyclerView.ViewHolder(parent) {
 
   private var thumbnailLoading: FluentFuture<Unit>? = null
@@ -123,14 +125,18 @@ class CatalogPagedViewHolder(
     this.idleAuthor.text = item.feedEntry.authorsCommaSeparated
     this.errorTitle.text = item.feedEntry.title
 
-    this.idleMeta.text = when (item.probableFormat) {
-      BOOK_FORMAT_EPUB ->
-        context.getString(R.string.catalogBookFormatEPUB)
-      BOOK_FORMAT_AUDIO ->
-        context.getString(R.string.catalogBookFormatAudioBook)
-      BOOK_FORMAT_PDF ->
-        context.getString(R.string.catalogBookFormatPDF)
-      null -> ""
+    if (config.showFormatLabel) {
+      this.idleMeta.text = when (item.probableFormat) {
+        BOOK_FORMAT_EPUB ->
+          context.getString(R.string.catalogBookFormatEPUB)
+        BOOK_FORMAT_AUDIO ->
+          context.getString(R.string.catalogBookFormatAudioBook)
+        BOOK_FORMAT_PDF ->
+          context.getString(R.string.catalogBookFormatPDF)
+        null -> ""
+      }
+    } else {
+      idleMeta.visibility = View.GONE
     }
 
     val targetHeight =

--- a/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogBookDetailFragmentTest.kt
+++ b/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogBookDetailFragmentTest.kt
@@ -1,0 +1,108 @@
+package org.nypl.simplified.ui.catalog
+
+import androidx.core.os.bundleOf
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.librarysimplified.services.api.Services
+import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.books.covers.BookCoverProviderType
+import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
+import org.nypl.simplified.listeners.api.FragmentListenerFinder
+import org.nypl.simplified.listeners.api.FragmentListenerType
+import org.nypl.simplified.ui.screen.ScreenSizeInformationType
+import java.net.URI
+
+@RunWith(AndroidJUnit4::class)
+class CatalogBookDetailFragmentTest {
+  private lateinit var scenario: FragmentScenario<CatalogBookDetailFragment>
+
+  @MockK private lateinit var mockBookCoversProvider: BookCoverProviderType
+  @MockK private lateinit var mockScreenInformation: ScreenSizeInformationType
+  @MockK private lateinit var mockBuildConfigService: BuildConfigurationServiceType
+  @MockK private lateinit var mockCatalogBorrowViewModel: CatalogBorrowViewModel
+  @MockK private lateinit var mockCatalogBookDetailViewModel: CatalogBookDetailViewModel
+  @MockK private lateinit var mockCatalogBookDetailEventListener: FragmentListenerType<CatalogBookDetailEvent>
+
+  @Before
+  fun setUp() {
+    MockKAnnotations.init(this, relaxed = true)
+
+    // Mock service directory to return mocked services
+    mockkObject(Services)
+    every {
+      Services.serviceDirectory().requireService(BookCoverProviderType::class.java)
+    } returns mockBookCoversProvider
+    every {
+      Services.serviceDirectory().requireService(ScreenSizeInformationType::class.java)
+    } returns mockScreenInformation
+    every {
+      Services.serviceDirectory().requireService(BuildConfigurationServiceType::class.java)
+    } returns mockBuildConfigService
+
+    // Mock ViewModel creation
+    mockkConstructor(CatalogBorrowViewModelFactory::class)
+    every {
+      anyConstructed<CatalogBorrowViewModelFactory>().create(CatalogBorrowViewModel::class.java)
+    } returns mockCatalogBorrowViewModel
+
+    mockkConstructor(CatalogBookDetailViewModelFactory::class)
+    every {
+      anyConstructed<CatalogBookDetailViewModelFactory>().create(CatalogBookDetailViewModel::class.java)
+    } returns mockCatalogBookDetailViewModel
+
+    // Mock ListenerFinder rather than traversing upwards towards a stubbed listener "repository"
+    mockkObject(FragmentListenerFinder)
+    every {
+      FragmentListenerFinder.findListener(any(), CatalogBookDetailEvent::class.java)
+    } returns mockCatalogBookDetailEventListener
+
+    val args = CatalogFeedArguments.CatalogFeedArgumentsRemote(
+      "title",
+      CatalogFeedOwnership.OwnedByAccount(AccountID.generate()),
+      URI.create("feedUri"),
+      false
+    )
+    val params = CatalogBookDetailFragmentParameters(
+      CatalogTestUtils.buildTestFeedEntryOPDS(),
+      args
+    )
+
+    scenario = launchFragmentInContainer(
+      fragmentArgs = bundleOf(CatalogBookDetailFragment.PARAMETERS_ID to params),
+      themeResId = R.style.SimplifiedTheme_NoActionBar
+    )
+  }
+
+  @Test
+  fun `details show format label when required by build configuration`() {
+    every { mockBuildConfigService.showFormatLabel } returns true
+
+    scenario.recreate()
+
+    onView(withId(R.id.bookDetailFormat)).check(matches(withText("eBook")))
+  }
+
+  @Test
+  fun `details hides book format label when required by build configuration`() {
+    every { mockBuildConfigService.showFormatLabel } returns false
+
+    scenario.recreate()
+
+    onView(withId(R.id.bookDetailFormat)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)))
+  }
+}

--- a/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogFeedFragmentTest.kt
+++ b/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogFeedFragmentTest.kt
@@ -18,14 +18,18 @@ import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.isNotEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.util.concurrent.FluentFuture
+import com.google.common.util.concurrent.SettableFuture
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -34,6 +38,7 @@ import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
@@ -48,6 +53,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.librarysimplified.services.api.Services
 import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.books.api.Book
+import org.nypl.simplified.books.book_registry.BookStatus
+import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.covers.BookCoverProviderType
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.feeds.api.Feed
@@ -69,23 +77,12 @@ class CatalogFeedFragmentTest {
 
   private lateinit var scenario: FragmentScenario<CatalogFeedFragment>
 
-  @MockK
-  private lateinit var mockBookCoversProvider: BookCoverProviderType
-
-  @MockK
-  private lateinit var mockScreenInformation: ScreenSizeInformationType
-
-  @MockK
-  private lateinit var mockBuildConfigService: BuildConfigurationServiceType
-
-  @MockK
-  private lateinit var mockCatalogBorrowViewModel: CatalogBorrowViewModel
-
-  @MockK
-  private lateinit var mockCatalogFeedViewModel: CatalogFeedViewModel
-
-  @MockK
-  private lateinit var mockCatalogFeedEventListener: FragmentListenerType<CatalogFeedEvent>
+  @MockK private lateinit var mockBookCoversProvider: BookCoverProviderType
+  @MockK private lateinit var mockScreenInformation: ScreenSizeInformationType
+  @MockK private lateinit var mockBuildConfigService: BuildConfigurationServiceType
+  @MockK private lateinit var mockCatalogBorrowViewModel: CatalogBorrowViewModel
+  @MockK private lateinit var mockCatalogFeedViewModel: CatalogFeedViewModel
+  @MockK private lateinit var mockCatalogFeedEventListener: FragmentListenerType<CatalogFeedEvent>
 
   private var testFeedStateLiveData = MutableLiveData<CatalogFeedState>()
 
@@ -122,7 +119,7 @@ class CatalogFeedFragmentTest {
       anyConstructed<CatalogFeedViewModelFactory>().create(CatalogFeedViewModel::class.java)
     } returns mockCatalogFeedViewModel
 
-    // Mock feedViewModel to return test-controlled LiveData
+    // Stub feedViewModel to return test-controlled LiveData
     every { mockCatalogFeedViewModel.feedStateLiveData } returns testFeedStateLiveData
 
     // Stub this for decorator configuration
@@ -282,6 +279,119 @@ class CatalogFeedFragmentTest {
     )
 
     onView(withId(R.id.feedWithoutGroupsList)).check(hasAdapterItemCount(2))
+  }
+
+  @Test
+  fun `on CatalogFeedWithoutGroups shows correct format label when required by build configuration`() {
+    val entry = CatalogTestUtils.buildTestFeedEntryOPDS()
+    val testEntriesLiveData = listOf<FeedEntry>(entry).asPagedList()
+
+    // Configure Catalog to show format labels
+    every { mockBuildConfigService.showFormatLabel } returns true
+
+    // We rely on an invocation of the provided callback on registration in order to
+    // reach a valid state in the ViewHolder. So we capture and invoke it here
+    val bookWithStatusCallbackSlot = slot<(BookWithStatus) -> Unit>()
+    every {
+      mockCatalogFeedViewModel.registerObserver(any(), capture(bookWithStatusCallbackSlot))
+    } answers {
+      bookWithStatusCallbackSlot.captured.invoke(
+        BookWithStatus(
+          Book(mockk(), AccountID.generate(), null, null, entry.feedEntry, emptyList()),
+          BookStatus.Loanable(mockk())
+        )
+      )
+    }
+
+    val ignoredFuture = FluentFuture.from(SettableFuture.create<Unit>())
+    every {
+      mockBookCoversProvider.loadThumbnailInto(
+        any(),
+        any(),
+        any(),
+        any()
+      )
+    } returns ignoredFuture
+
+    testFeedStateLiveData.value = CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithoutGroups(
+      mockk(), // Pass in mock FeedArguments as it is not used when handling state
+      testEntriesLiveData,
+      emptyList(),
+      emptyMap(),
+      null,
+      "title"
+    )
+
+    onView(withId(R.id.feedWithoutGroupsList)).check(
+      matches(
+        atPositionOnView(
+          0,
+          hasDescendant(
+            allOf(
+              withId(R.id.bookCellIdleMeta),
+              withText("eBook"),
+              withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)
+            )
+          )
+        )
+      )
+    )
+  }
+
+  @Test
+  fun `on CatalogFeedWithoutGroups hides format label when required by build configuration`() {
+    val entry = CatalogTestUtils.buildTestFeedEntryOPDS()
+    val testEntriesLiveData = listOf<FeedEntry>(entry).asPagedList()
+
+    // Configure Catalog to show format labels
+    every { mockBuildConfigService.showFormatLabel } returns false
+
+    // We rely on an invocation of the provided callback on registration in order to
+    // reach a valid state in the ViewHolder. So we capture and invoke it here
+    val bookWithStatusCallbackSlot = slot<(BookWithStatus) -> Unit>()
+    every {
+      mockCatalogFeedViewModel.registerObserver(any(), capture(bookWithStatusCallbackSlot))
+    } answers {
+      bookWithStatusCallbackSlot.captured.invoke(
+        BookWithStatus(
+          Book(mockk(), AccountID.generate(), null, null, entry.feedEntry, emptyList()),
+          BookStatus.Loanable(mockk())
+        )
+      )
+    }
+
+    val ignoredFuture = FluentFuture.from(SettableFuture.create<Unit>())
+    every {
+      mockBookCoversProvider.loadThumbnailInto(
+        any(),
+        any(),
+        any(),
+        any()
+      )
+    } returns ignoredFuture
+
+    testFeedStateLiveData.value = CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithoutGroups(
+      mockk(), // Pass in mock FeedArguments as it is not used when handling state
+      testEntriesLiveData,
+      emptyList(),
+      emptyMap(),
+      null,
+      "title"
+    )
+
+    onView(withId(R.id.feedWithoutGroupsList)).check(
+      matches(
+        atPositionOnView(
+          0,
+          hasDescendant(
+            allOf(
+              withId(R.id.bookCellIdleMeta),
+              withEffectiveVisibility(ViewMatchers.Visibility.GONE)
+            )
+          )
+        )
+      )
+    )
   }
 
   @Test

--- a/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogTestUtils.kt
+++ b/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogTestUtils.kt
@@ -1,0 +1,43 @@
+package org.nypl.simplified.ui.catalog
+
+import one.irradia.mime.api.MIMEType
+import org.joda.time.DateTime
+import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.feeds.api.FeedEntry
+import org.nypl.simplified.opds.core.OPDSAcquisition
+import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
+import org.nypl.simplified.opds.core.OPDSAvailabilityLoanable
+import java.net.URI
+
+object CatalogTestUtils {
+  /*
+  * We can't easily mock parts of FeedEntries (BookFormatDefinition) due to
+  * https://github.com/mockk/mockk/issues/473
+  * so here's a quick way to get a relatively-useable epub FeedEntry
+  */
+  fun buildTestFeedEntryOPDS(): FeedEntry.FeedEntryOPDS {
+    val entry = FeedEntry.FeedEntryOPDS(
+      AccountID.generate(),
+      OPDSAcquisitionFeedEntry.newBuilder(
+        "in_id",
+        "in_title",
+        DateTime.now(),
+        OPDSAvailabilityLoanable.get(),
+      )
+        .addAcquisition(
+          OPDSAcquisition(
+            OPDSAcquisition.Relation.ACQUISITION_BORROW,
+            URI.create("some-uri"),
+            MIMEType(
+              "application",
+              "epub+zip",
+              emptyMap()
+            ),
+            emptyList()
+          )
+        )
+        .build()
+    )
+    return entry
+  }
+}


### PR DESCRIPTION
**What's this do?**
This PR hides the 'eBook' label seen in the Catalog and Book Detail pages for the openEbooks application. The SimplyE app will still see these format-specific labels.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-527

**How should this be tested? / Do these changes have associated tests?**
Launch openEbooks and check on the ungrouped Catalog and Book Detail pages to see if the 'eBook' label is no longer present. Similarly check those locations in SimplyE to ensure they are still there.

There have been corresponding tests for this build configuration flag driven visibility in the CatalogFeedFragmentTest and CatalogBookDetailFragmentTest.

**Dependencies for merging? Releasing to production?**
No changes to dependencies

**Has the application documentation been updated for these changes?**
No documentation changes

**Did someone actually run this code to verify it works?**
Tested locally on my Pixel 5a.