### PR TITLE
OE-618: Menu on the privacy page does not open

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/WebViewActivity.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/WebViewActivity.kt
@@ -1,5 +1,6 @@
 package org.nypl.simplified.ui.accounts
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import android.webkit.WebView
@@ -32,6 +33,7 @@ class WebViewActivity : AppCompatActivity() {
   private val faq = "https://www.openebooks.org/faq"
   private lateinit var url: String
 
+  @SuppressLint("SetJavaScriptEnabled")
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     binding = ActivityWebviewBinding.inflate(layoutInflater)
@@ -51,13 +53,14 @@ class WebViewActivity : AppCompatActivity() {
     /**
      * Load URL
      */
-    binding.page.loadUrl(url)
     binding.page.webViewClient = object : WebViewClient() {
       override fun onPageFinished(view: WebView, url: String) {
         logger.debug("Web page loaded")
         binding.loading.visibility = View.GONE
       }
     }
+    binding.page.settings.javaScriptEnabled = true
+    binding.page.loadUrl(url)
 
     /**
      * Handle back button click


### PR DESCRIPTION
**What's this do?**
Enables javascript on the WebView that loads the privacy policy.

**Why are we doing this? (w/ JIRA link if applicable)**
[OE-618: Menu on the privacy page does not open](https://jira.nypl.org/browse/OE-618)

**How should this be tested? / Do these changes have associated tests?**
1. Launch the app
2. Tap Privacy Notice
3. Tap the hamburger menu button in the top right corner of the privacy policy screen.
4. Examine the menu opening and closing

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 

https://user-images.githubusercontent.com/15109016/180889973-4cb72eca-6aa5-4a2a-bfbb-33aecdf224e4.mp4


