### PR TITLE
OE-615: Access code and pin fields are blank after logging in

### DIFF
--- a/simplified-app-openebooks/gradle.properties
+++ b/simplified-app-openebooks/gradle.properties
@@ -2,7 +2,7 @@ POM_ARTIFACT_ID=org.nypl.labs.OpenEbooks.app
 POM_DESCRIPTION=Open eBooks(Application)
 POM_NAME=org.nypl.labs.OpenEbooks.app
 POM_PACKAGING=apk
-VERSION_NAME=2.5.0
+VERSION_NAME=2.5.1-SNAPSHOT
 
 # Skip this project unless the property `org.librarysimplified.drm.enabled=true`
 # is also defined.


### PR DESCRIPTION
**What's this do?**
For the sake of parity, here we hide the login input fields with the user is logged in via Clever. Currently, there is no design for this UI state.

**Why are we doing this? (w/ JIRA link if applicable)**
[OE-615: Access code and pin fields are blank after logging in](https://jira.nypl.org/browse/OE-615)

**How should this be tested? / Do these changes have associated tests?**
Log in and log out to see the fields visibility toggled.

**Dependencies for merging? Releasing to production?**
This is supposed to go out with OE 2.5.1.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 
