### PR TITLE
Oe 606/download complete footer

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -191,7 +191,7 @@ class CatalogFeedFragment : Fragment(), AgeGateDialog.BirthYearSelectedListener 
 
     sharedListConfiguration(feedWithoutGroupsList)
 
-    withoutGroupsAdapter = CatalogPagedAdapter(bookCoverProvider, configService)
+    withoutGroupsAdapter = CatalogPagedAdapter(bookCoverProvider, configService, lifecycleScope)
 
     val withoutGroupsSwipeContainer = binding.feedWithoutGroups.feedWithoutGroupsSwipeContainer
     withoutGroupsSwipeContainer.setOnRefreshListener {

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -19,7 +19,12 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.rx2.asFlow
 import org.joda.time.DateTime
 import org.joda.time.LocalDateTime
 import org.nypl.simplified.accounts.api.AccountEvent
@@ -35,6 +40,7 @@ import org.nypl.simplified.analytics.api.AnalyticsEvent
 import org.nypl.simplified.analytics.api.AnalyticsType
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookFormat
+import org.nypl.simplified.books.api.BookID
 import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookStatusEvent
@@ -68,6 +74,7 @@ import org.nypl.simplified.ui.catalog.CatalogFeedState.CatalogFeedLoaded.Catalog
 import org.nypl.simplified.ui.catalog.CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithGroups
 import org.nypl.simplified.ui.catalog.CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithoutGroups
 import org.nypl.simplified.ui.catalog.withoutGroups.BookItem
+import org.nypl.simplified.ui.catalog.withoutGroups.DownloadState
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.nypl.simplified.ui.thread.api.UIExecutor
 import org.slf4j.LoggerFactory
@@ -131,6 +138,8 @@ class CatalogFeedViewModel(
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(::onFeedLoaderResult)
     )
+
+  private val downloadingBooks = mutableMapOf<BookID, BookStatus>()
 
   private fun onAccountEvent(event: AccountEvent) {
     when (event) {
@@ -534,6 +543,8 @@ class CatalogFeedViewModel(
 
   @VisibleForTesting
   internal fun buildBookItems(entries: PagingData<FeedEntry>): PagingData<BookItem> {
+    logger.debug("[Rob] buildBookItems called")
+    logger.debug("[Rob] current downloadingBooks: ${downloadingBooks.size}, ${downloadingBooks.entries.firstOrNull()?.key.toString()}")
     return entries.map {
       when (it) {
         is FeedEntry.FeedEntryCorrupt -> BookItem.Corrupt(it)
@@ -894,17 +905,39 @@ class CatalogFeedViewModel(
     }
   }
 
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun buildStatusFlowForBook(book: BookID): Flow<BookStatus> {
+    return bookRegistry.bookEvents().asFlow()
+      .filter { it.bookId == book }
+      .map { it.statusNow }
+      .filterNotNull()
+//    return callbackFlow {
+//      viewModelScope.launch {
+//        bookRegistry.bookEvents().filter { it.bookId == book }.asFlow().collect {
+//
+//        }
+//      }
+//    }
+  }
+
+  //downloading w/progress
+  //downloading w/o progress
+  //download complete
+  //normal idle mode
+
   @VisibleForTesting
   internal fun buildBookItem(
     entry: FeedEntry.FeedEntryOPDS,
-    bookWithStatus: BookWithStatus?,
+    bookWithStatus: BookWithStatus,
     listener: CatalogPagedViewListener
   ): BookItem {
-    return when (val status = bookWithStatus!!.status) {
+    return when (val status = bookWithStatus.status) {
       /*
       * Error States
       */
       is BookStatus.FailedDownload -> {
+        logger.debug("[Rob] FailedDownload for ${entry.feedEntry.title}")
+        downloadingBooks.remove(bookWithStatus.book.id)
         BookItem.Error(
           entry = entry,
           failure = status.result,
@@ -1026,6 +1059,9 @@ class CatalogFeedViewModel(
         )
       }
       is BookStatus.Loaned.LoanedDownloaded -> {
+        logger.debug("[Rob] LoanedDownloaded for ${entry.feedEntry.title}")
+        val justDownloaded = downloadingBooks.remove(bookWithStatus.book.id)?.let { true } ?: false
+
         val textConfig = when (val format = bookWithStatus.book.findPreferredFormat()) {
           is BookFormat.BookFormatEPUB,
           is BookFormat.BookFormatPDF -> {
@@ -1059,7 +1095,8 @@ class CatalogFeedViewModel(
             override fun primaryButton() = primaryButton
             override fun secondaryButton(): BookItem.Idle.IdleButtonConfig? = null
           },
-          loanExpiry = status.loanExpiryDate
+          loanExpiry = status.loanExpiryDate,
+          downloadState = if (justDownloaded) DownloadState.Complete else null
         )
       }
       is BookStatus.Loaned.LoanedNotDownloaded -> {
@@ -1087,12 +1124,29 @@ class CatalogFeedViewModel(
       is BookStatus.RequestingRevoke,
       is BookStatus.DownloadExternalAuthenticationInProgress,
       is BookStatus.DownloadWaitingForExternalAuthentication -> {
-        BookItem.InProgress(entry = entry)
+        downloadingBooks[bookWithStatus.book.id] = status
+        BookItem.Idle(
+          entry = entry,
+          actions = object : BookItem.Idle.IdleActions {
+            override fun openBookDetail() {}
+            override fun primaryButton(): BookItem.Idle.IdleButtonConfig? = null
+            override fun secondaryButton(): BookItem.Idle.IdleButtonConfig? = null
+          },
+          downloadState = DownloadState.InProgress()
+        )
       }
       is BookStatus.Downloading -> {
-        BookItem.InProgress(
+        logger.debug("[Rob] Determinate progress of ${status.progressPercent?.toInt()} for ${entry.feedEntry.title}")
+        downloadingBooks[bookWithStatus.book.id] = status
+        BookItem.Idle(
           entry = entry,
-          progress = status.progressPercent?.toInt()
+          actions = object : BookItem.Idle.IdleActions {
+            override fun openBookDetail() {}
+            override fun primaryButton(): BookItem.Idle.IdleButtonConfig? = null
+            override fun secondaryButton(): BookItem.Idle.IdleButtonConfig? = null
+
+          },
+          downloadState = DownloadState.InProgress(status.progressPercent?.toInt())
         )
       }
     }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -903,26 +903,6 @@ class CatalogFeedViewModel(
     }
   }
 
-  @OptIn(ExperimentalCoroutinesApi::class)
-  fun buildStatusFlowForBook(book: BookID): Flow<BookStatus> {
-    return bookRegistry.bookEvents().asFlow()
-      .filter { it.bookId == book }
-      .map { it.statusNow }
-      .filterNotNull()
-//    return callbackFlow {
-//      viewModelScope.launch {
-//        bookRegistry.bookEvents().filter { it.bookId == book }.asFlow().collect {
-//
-//        }
-//      }
-//    }
-  }
-
-  // downloading w/progress
-  // downloading w/o progress
-  // download complete
-  // normal idle mode
-
   @VisibleForTesting
   internal fun buildBookItem(
     entry: FeedEntry.FeedEntryOPDS,

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -19,12 +19,7 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.rx2.asFlow
 import org.joda.time.DateTime
 import org.joda.time.LocalDateTime
 import org.nypl.simplified.accounts.api.AccountEvent

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/BookItem.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/BookItem.kt
@@ -17,7 +17,8 @@ sealed class BookItem {
   data class Idle(
     val entry: FeedEntry.FeedEntryOPDS,
     val actions: IdleActions,
-    val loanExpiry: DateTime? = null
+    val loanExpiry: DateTime? = null,
+    val downloadState: DownloadState? = null
   ) : BookItem() {
     override val type = IDLE
     val title: String? = entry.feedEntry.title
@@ -67,4 +68,13 @@ sealed class BookItem {
     val author: String? = entry.feedEntry.authorsCommaSeparated
     val isIndeterminate = progress == null
   }
+}
+
+sealed class DownloadState {
+  abstract val progress: Int?
+  fun isIndeterminate() = progress == null
+  fun isComplete() = progress == 100
+
+  object Complete: DownloadState() { override val progress = 100 }
+  class InProgress(override val progress: Int? = null): DownloadState()
 }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/BookItem.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/BookItem.kt
@@ -75,6 +75,12 @@ sealed class DownloadState {
   fun isIndeterminate() = progress == null
   fun isComplete() = progress == 100
 
-  object Complete: DownloadState() { override val progress = 100 }
-  class InProgress(override val progress: Int? = null): DownloadState()
+  object Complete : DownloadState() {
+    override val progress = 100
+  }
+
+  class InProgress(
+    override val progress: Int? = null,
+    val isStarting: Boolean = false
+  ) : DownloadState()
 }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/CatalogPagedAdapter.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/CatalogPagedAdapter.kt
@@ -16,7 +16,6 @@ import org.nypl.simplified.ui.catalog.withoutGroups.BookItem.Type.CORRUPT
 import org.nypl.simplified.ui.catalog.withoutGroups.BookItem.Type.ERROR
 import org.nypl.simplified.ui.catalog.withoutGroups.BookItem.Type.IDLE
 import org.nypl.simplified.ui.catalog.withoutGroups.BookItem.Type.LOADING
-import org.slf4j.LoggerFactory
 
 class CatalogPagedAdapter(
   private val bookCoverProvider: BookCoverProviderType,
@@ -25,7 +24,6 @@ class CatalogPagedAdapter(
 ) : PagingDataAdapter<BookItem, RecyclerView.ViewHolder>(
   CatalogPagedAdapterDiffing.comparisonCallback
 ) {
-  private val logger = LoggerFactory.getLogger(javaClass)
 
   override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
     val item = getItem(position)
@@ -68,14 +66,6 @@ class CatalogPagedAdapter(
 
   override fun getItemViewType(position: Int): Int {
     return getItem(position)?.type?.ordinal ?: -1
-  }
-
-  override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
-    super.onViewRecycled(holder)
-    if (holder is BookIdleViewHolder) {
-      logger.debug("Unbind called for $holder")
-      holder.unbind()
-    }
   }
 }
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/CatalogPagedBindingAdapters.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/CatalogPagedBindingAdapters.kt
@@ -5,6 +5,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.os.ConfigurationCompat
 import androidx.databinding.BindingAdapter
+import com.google.android.material.progressindicator.LinearProgressIndicator
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import org.nypl.simplified.books.book_database.api.BookFormats
@@ -53,4 +54,10 @@ internal fun TextView.formatDownloadPercentage(progress: Int?) {
   } ?: run {
     visibility = View.INVISIBLE
   }
+}
+
+@BindingAdapter("configureProgressBar")
+internal fun LinearProgressIndicator.configureProgressBar(value: Int?) {
+  isIndeterminate = value == null
+  value?.let { progress = it }
 }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/CatalogViewHolders.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/CatalogViewHolders.kt
@@ -1,8 +1,9 @@
 package org.nypl.simplified.ui.catalog.withoutGroups
 
 import android.view.View
-import androidx.core.view.doOnNextLayout
-import androidx.core.view.doOnPreDraw
+import android.view.ViewGroup
+import android.view.animation.Animation
+import android.view.animation.Transformation
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
@@ -16,24 +17,19 @@ import org.nypl.simplified.ui.catalog.databinding.BookCellCorruptBinding
 import org.nypl.simplified.ui.catalog.databinding.BookCellErrorBinding
 import org.nypl.simplified.ui.catalog.databinding.BookCellIdleBinding
 import org.nypl.simplified.ui.catalog.databinding.BookCellInProgressBinding
-import org.slf4j.LoggerFactory
 
 class BookIdleViewHolder(
   private val binding: BookCellIdleBinding,
   private val bookCoverProvider: BookCoverProviderType,
   private val showFormatLabel: Boolean,
-  private val viewLifecycleScope: CoroutineScope
+  private val viewLifecycleScope: CoroutineScope,
 ) : RecyclerView.ViewHolder(binding.root) {
 
   companion object {
     const val DOWNLOAD_COMPLETE_FOOTER_DElAY = 5000L
   }
 
-  private val logger = LoggerFactory.getLogger(javaClass)
-
   private var footerAnimationJob: Job? = null
-  private var originalHeight: Int? = null
-  private var expandedHeight: Int? = null
 
   fun bind(item: BookItem.Idle) {
     binding.idleItem = item
@@ -45,23 +41,44 @@ class BookIdleViewHolder(
     configureButtons(item)
   }
 
-  fun setupAnimation() {
-    logger.debug("setupAnimation")
-    binding.bookCellIdle.doOnPreDraw { view ->
-      logger.debug("doOnPreDraw")
-      originalHeight = view.height
+  private fun animatedFooterCollapse(view: View) {
+    val fullHeight = view.measuredHeight
 
-      binding.bookCellIdleDownloadFooter.visibility = View.VISIBLE
-      binding.bookCellIdle.doOnNextLayout {
-        logger.debug("doOnNextLayout")
-        expandedHeight = it.height
-        binding.bookCellIdleDownloadFooter.visibility = View.GONE
+    val animation = object : Animation() {
+      override fun applyTransformation(interpolatedTime: Float, t: Transformation?) {
+        if (interpolatedTime == 1f) {
+          view.visibility = View.GONE
+        } else {
+          view.layoutParams.height = fullHeight - (fullHeight * interpolatedTime).toInt()
+          view.requestLayout()
+        }
       }
     }
+
+    animation.duration = (fullHeight / view.context.resources.displayMetrics.density).toLong()
+    view.startAnimation(animation)
   }
 
-  fun unbind() {
-    footerAnimationJob?.cancel()
+  private fun animatedFooterExpand(view: View) {
+    view.measure(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    val fullHeight = view.measuredHeight
+
+    view.layoutParams.height = 0
+    view.visibility = View.VISIBLE
+
+    val animation = object : Animation() {
+      override fun applyTransformation(interpolatedTime: Float, t: Transformation?) {
+        view.layoutParams.height =
+          if (interpolatedTime == 1f) ViewGroup.LayoutParams.WRAP_CONTENT
+          else (fullHeight * interpolatedTime).toInt()
+        view.requestLayout()
+      }
+
+      override fun willChangeBounds() = true
+    }
+
+    animation.duration = (fullHeight / view.context.resources.displayMetrics.density).toLong()
+    view.startAnimation(animation)
   }
 
   private fun configureDownloadViews(item: BookItem.Idle) {
@@ -73,13 +90,24 @@ class BookIdleViewHolder(
 
         footerAnimationJob = viewLifecycleScope.launch {
           delay(DOWNLOAD_COMPLETE_FOOTER_DElAY)
-          binding.bookCellIdleDownloadFooter.visibility = View.GONE
+          animatedFooterCollapse(binding.bookCellIdleDownloadFooter)
+        }
+        footerAnimationJob?.invokeOnCompletion {
+          binding.bookCellIdleDownloadFooter.isVisible = true
         }
       }
       is DownloadState.InProgress -> {
-        binding.bookCellIdleDownloadFooter.visibility = View.VISIBLE
+        binding.bookCellIdleDownloadFooter.visibility = View.INVISIBLE
+        binding.bookCellIdleDownloadFooter.let {
+          if (state.isStarting) {
+            viewLifecycleScope.launch {
+              delay(250)
+              animatedFooterExpand(it)
+            }
+          } else it.visibility = View.VISIBLE
+        }
         binding.bookCellIdleDownloadInProgress.visibility = View.VISIBLE
-        binding.bookCellIdleDownloadComplete.visibility = View.INVISIBLE
+        binding.bookCellIdleDownloadComplete.visibility = View.GONE
 
         state.progress?.let { progress ->
           binding.bookCellIdleCoverProgress.isIndeterminate = false
@@ -115,7 +143,10 @@ class BookIdleViewHolder(
   }
 
   private fun configureButtons(item: BookItem.Idle) {
-    binding.bookCellIdleButtons.isVisible = item.downloadState !is DownloadState.InProgress
+    if (item.downloadState is DownloadState.InProgress) {
+      binding.bookCellIdlePrimaryButton.visibility = View.GONE
+      binding.bookCellIdleSecondaryButton.visibility = View.GONE
+    }
 
     item.actions.primaryButton()?.let {
       binding.bookCellIdlePrimaryButton.visibility = View.VISIBLE

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/CatalogViewHolders.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/withoutGroups/CatalogViewHolders.kt
@@ -1,7 +1,14 @@
 package org.nypl.simplified.ui.catalog.withoutGroups
 
 import android.view.View
+import androidx.core.view.doOnNextLayout
+import androidx.core.view.doOnPreDraw
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.nypl.simplified.books.covers.BookCoverProviderType
 import org.nypl.simplified.futures.FluentFutureExtensions.map
 import org.nypl.simplified.ui.catalog.R
@@ -9,20 +16,82 @@ import org.nypl.simplified.ui.catalog.databinding.BookCellCorruptBinding
 import org.nypl.simplified.ui.catalog.databinding.BookCellErrorBinding
 import org.nypl.simplified.ui.catalog.databinding.BookCellIdleBinding
 import org.nypl.simplified.ui.catalog.databinding.BookCellInProgressBinding
+import org.slf4j.LoggerFactory
 
 class BookIdleViewHolder(
   private val binding: BookCellIdleBinding,
   private val bookCoverProvider: BookCoverProviderType,
-  private val showFormatLabel: Boolean
+  private val showFormatLabel: Boolean,
+  private val viewLifecycleScope: CoroutineScope
 ) : RecyclerView.ViewHolder(binding.root) {
+
+  companion object {
+    const val DOWNLOAD_COMPLETE_FOOTER_DElAY = 5000L
+  }
+
+  private val logger = LoggerFactory.getLogger(javaClass)
+
+  private var footerAnimationJob: Job? = null
+  private var originalHeight: Int? = null
+  private var expandedHeight: Int? = null
 
   fun bind(item: BookItem.Idle) {
     binding.idleItem = item
     binding.executePendingBindings()
 
     loadCover(item)
-    configureButtons(item)
     toggleFormatLabelVisibility()
+    configureDownloadViews(item)
+    configureButtons(item)
+  }
+
+  fun setupAnimation() {
+    logger.debug("setupAnimation")
+    binding.bookCellIdle.doOnPreDraw { view ->
+      logger.debug("doOnPreDraw")
+      originalHeight = view.height
+
+      binding.bookCellIdleDownloadFooter.visibility = View.VISIBLE
+      binding.bookCellIdle.doOnNextLayout {
+        logger.debug("doOnNextLayout")
+        expandedHeight = it.height
+        binding.bookCellIdleDownloadFooter.visibility = View.GONE
+      }
+    }
+  }
+
+  fun unbind() {
+    footerAnimationJob?.cancel()
+  }
+
+  private fun configureDownloadViews(item: BookItem.Idle) {
+    when (val state = item.downloadState) {
+      DownloadState.Complete -> {
+        binding.bookCellIdleDownloadFooter.visibility = View.VISIBLE
+        binding.bookCellIdleDownloadInProgress.visibility = View.INVISIBLE
+        binding.bookCellIdleDownloadComplete.visibility = View.VISIBLE
+
+        footerAnimationJob = viewLifecycleScope.launch {
+          delay(DOWNLOAD_COMPLETE_FOOTER_DElAY)
+          binding.bookCellIdleDownloadFooter.visibility = View.GONE
+        }
+      }
+      is DownloadState.InProgress -> {
+        binding.bookCellIdleDownloadFooter.visibility = View.VISIBLE
+        binding.bookCellIdleDownloadInProgress.visibility = View.VISIBLE
+        binding.bookCellIdleDownloadComplete.visibility = View.INVISIBLE
+
+        state.progress?.let { progress ->
+          binding.bookCellIdleCoverProgress.isIndeterminate = false
+          binding.bookCellIdleCoverProgress.progress = progress
+        } ?: run {
+          binding.bookCellIdleCoverProgress.isIndeterminate = true
+        }
+      }
+      null -> {
+        binding.bookCellIdleDownloadFooter.visibility = View.GONE
+      }
+    }
   }
 
   private fun toggleFormatLabelVisibility() {
@@ -46,7 +115,10 @@ class BookIdleViewHolder(
   }
 
   private fun configureButtons(item: BookItem.Idle) {
+    binding.bookCellIdleButtons.isVisible = item.downloadState !is DownloadState.InProgress
+
     item.actions.primaryButton()?.let {
+      binding.bookCellIdlePrimaryButton.visibility = View.VISIBLE
       binding.bookCellIdlePrimaryButton.text = it.getText(itemView.context)
       binding.bookCellIdlePrimaryButton.contentDescription = it.getDescription(itemView.context)
       binding.bookCellIdlePrimaryButton.setOnClickListener { _ -> it.onClick() }
@@ -55,6 +127,7 @@ class BookIdleViewHolder(
     }
 
     item.actions.secondaryButton()?.let {
+      binding.bookCellIdleSecondaryButton.visibility = View.VISIBLE
       binding.bookCellIdleSecondaryButton.text = it.getText(itemView.context)
       binding.bookCellIdleSecondaryButton.contentDescription = it.getDescription(itemView.context)
       binding.bookCellIdleSecondaryButton.setOnClickListener { _ -> it.onClick() }

--- a/simplified-ui-catalog/src/main/res/drawable/ic_catalog_download_complete.xml
+++ b/simplified-ui-catalog/src/main/res/drawable/ic_catalog_download_complete.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+  <path
+      android:pathData="M16,16m-16,0a16,16 0,1 1,32 0a16,16 0,1 1,-32 0"
+      android:fillColor="#FFFBFB"/>
+  <group>
+    <clip-path
+        android:pathData="M5.0526,4.2105h23.5789v23.5789h-23.5789z"/>
+    <path
+        android:pathData="M9.9649,21.8947H23.7193V23.8596H9.9649V21.8947ZM14.4842,19.2421L9.9649,14.7228L11.9298,12.8561L14.4842,15.4105L21.7544,8.1403L23.7193,10.1052L14.4842,19.2421Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
@@ -27,9 +27,9 @@
       android:layout_height="@dimen/catalogFeedCellHeight"
       android:onClick="@{() -> idleItem.actions.openBookDetail()}"
       app:coverContentDescriptionForItem="@{idleItem.entry}"
-      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintBottom_toTopOf="@id/bookCellIdleDownloadFooter"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
+      app:layout_constraintTop_toTopOf="@id/bookCellIdleTitle" />
 
     <ProgressBar
       android:id="@+id/bookCellIdleCoverProgress"
@@ -54,6 +54,7 @@
       android:text="@{idleItem.title}"
       android:textSize="16sp"
       android:textStyle="bold"
+      app:layout_constraintBottom_toTopOf="@id/bookCellIdleAuthor"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
       app:layout_constraintTop_toTopOf="parent"
@@ -69,6 +70,7 @@
       android:maxLines="1"
       android:text="@{idleItem.author}"
       android:textSize="14sp"
+      app:layout_constraintBottom_toTopOf="@id/bookCellIdleMeta"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
       app:layout_constraintTop_toBottomOf="@id/bookCellIdleTitle"
@@ -85,6 +87,7 @@
       android:textSize="12sp"
       android:textStyle="italic"
       app:formatLabelForEntry="@{idleItem.entry}"
+      app:layout_constraintBottom_toTopOf="@id/bookCellIdleExpiryInfo"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
       app:layout_constraintTop_toBottomOf="@id/bookCellIdleAuthor"
@@ -94,15 +97,16 @@
       android:id="@+id/bookCellIdleExpiryInfo"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
-      android:layout_marginStart="16dp"
+      android:layout_marginHorizontal="16dp"
       android:layout_marginTop="4dp"
-      android:layout_marginEnd="16dp"
+      android:layout_marginBottom="8dp"
       android:drawableLeft="@drawable/catalog_feed_expiry_info_clock_icon"
       android:drawablePadding="4dp"
       android:ellipsize="end"
       android:maxLines="1"
       android:textSize="11sp"
       app:formatOptionalExpiryInfo="@{idleItem.loanExpiry}"
+      app:layout_constraintBottom_toTopOf="@id/bookCellIdleButtons"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
       app:layout_constraintTop_toBottomOf="@id/bookCellIdleMeta"
@@ -116,7 +120,7 @@
       android:layout_marginTop="8dp"
       android:layout_marginEnd="16dp"
       android:layout_marginBottom="8dp"
-      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintBottom_toBottomOf="@id/bookCellIdleCover"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
       app:layout_constraintTop_toBottomOf="@id/bookCellIdleExpiryInfo">
@@ -126,6 +130,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingHorizontal="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="get"
@@ -137,11 +142,112 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:paddingHorizontal="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/bookCellIdlePrimaryButton"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="revoke"
         tools:visibility="visible" />
 
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/bookCellIdleDownloadFooter"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="?attr/simplifiedColorText"
+      android:visibility="gone"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/bookCellIdleCover"
+      tools:background="@color/simplified_material_green_primary"
+      tools:visibility="visible">
+
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/bookCellIdleDownloadInProgress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageButton
+          android:id="@+id/bookCellIdleDownloadCancel"
+          android:layout_width="48dp"
+          android:layout_height="24dp"
+          android:layout_marginLeft="16dp"
+          android:adjustViewBounds="false"
+          android:background="@android:color/transparent"
+          android:clickable="false"
+          android:contentDescription="@string/catalogAccessibilityBookDownloadCancel"
+          android:src="@drawable/catalog_feed_cancel_download_icon"
+          android:visibility="invisible"
+          app:layout_constraintBottom_toBottomOf="@id/bookCellIdleDownloadBar"
+          app:layout_constraintEnd_toStartOf="@id/bookCellIdleDownloadBar"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="@id/bookCellIdleDownloadBar" />
+
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+          android:id="@+id/bookCellIdleDownloadBar"
+          android:layout_width="0dp"
+          android:layout_height="24dp"
+          android:layout_marginHorizontal="16dp"
+          android:layout_marginTop="20dp"
+          android:layout_marginBottom="8dp"
+          app:configureProgressBar="@{idleItem.downloadState.progress}"
+          app:indicatorColor="@color/almost_black"
+          app:layout_constraintBottom_toTopOf="@id/bookCellIdleDownloadDescription"
+          app:layout_constraintEnd_toStartOf="@id/bookCellIdleDownloadPercentage"
+          app:layout_constraintStart_toEndOf="@id/bookCellIdleDownloadCancel"
+          app:layout_constraintTop_toTopOf="parent"
+          app:trackColor="@color/white" />
+
+        <TextView
+          android:id="@+id/bookCellIdleDownloadPercentage"
+          android:layout_width="48dp"
+          android:layout_height="wrap_content"
+          android:layout_marginRight="16dp"
+          android:gravity="center"
+          android:textColor="@color/almost_black"
+          app:formatDownloadPercentage="@{idleItem.downloadState.progress}"
+          app:layout_constraintBottom_toBottomOf="@id/bookCellIdleDownloadBar"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toEndOf="@id/bookCellIdleDownloadBar"
+          app:layout_constraintTop_toTopOf="@id/bookCellIdleDownloadBar"
+          tools:text="60%" />
+
+        <TextView
+          android:id="@+id/bookCellIdleDownloadDescription"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginBottom="4dp"
+          android:gravity="center"
+          android:text="@string/catalogDownloading"
+          android:textColor="@color/almost_black"
+          android:textSize="12sp"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="@id/bookCellIdleDownloadBar"
+          app:layout_constraintStart_toStartOf="@id/bookCellIdleDownloadBar"
+          app:layout_constraintTop_toBottomOf="@id/bookCellIdleDownloadBar"
+          tools:textColor="@color/almost_black" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
+      <TextView
+        android:id="@+id/bookCellIdleDownloadComplete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:drawableRight="@drawable/ic_catalog_download_complete"
+        android:drawablePadding="5dp"
+        android:gravity="center"
+        android:paddingVertical="8dp"
+        android:text="@string/catalogDownloadComplete"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
     </androidx.constraintlayout.widget.ConstraintLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
@@ -27,7 +27,6 @@
       android:layout_height="@dimen/catalogFeedCellHeight"
       android:onClick="@{() -> idleItem.actions.openBookDetail()}"
       app:coverContentDescriptionForItem="@{idleItem.entry}"
-      app:layout_constraintBottom_toTopOf="@id/bookCellIdleDownloadFooter"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="@id/bookCellIdleTitle" />
 
@@ -219,7 +218,7 @@
 
         <TextView
           android:id="@+id/bookCellIdleDownloadDescription"
-          android:layout_width="0dp"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginBottom="4dp"
           android:gravity="center"

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -71,6 +71,7 @@
   <string name="catalogRequesting">Requesting…</string>
   <string name="catalogDownloading">Downloading</string>
   <string name="catalogDownloadingEllipsis">Downloading…</string>
+  <string name="catalogDownloadComplete">Download complete!</string>
   <string name="catalogReserve">Reserve</string>
   <string name="catalogRetry">Retry</string>
   <string name="catalogReturn">Return</string>


### PR DESCRIPTION
**What's this do?**
Adds a 'Download Complete' text to the download footer for a just-finished downloading book that will disappear after a short time. Also added animations to the display/hiding of this footer, so that book items appear to more naturally expand/collapse as the download footer is toggled. 

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-606

**How should this be tested? / Do these changes have associated tests?**
There are automated tests that have added for these changes. Otherwise the changes can be seen by downloading any book in an ungrouped list. 

**Dependencies for merging? Releasing to production?**
No dependencies changed

**Has the application documentation been updated for these changes?**
No documentation changes

**Did someone actually run this code to verify it works?**
Tested locally on my Pixel 5a
