### PR TITLE
SMA-398: Minor Test Upgrades

### DIFF
--- a/simplified-cardcreator/src/test/kotlin/org/nypl/simplified/cardcreator/ui/AccountInformationFragmentTest.kt
+++ b/simplified-cardcreator/src/test/kotlin/org/nypl/simplified/cardcreator/ui/AccountInformationFragmentTest.kt
@@ -21,6 +21,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.hamcrest.CoreMatchers.not
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -45,7 +46,7 @@ class AccountInformationFragmentTest {
       ApplicationProvider.getApplicationContext()
     )
 
-    scenario = launchFragmentInContainer() {
+    scenario = launchFragmentInContainer {
       AccountInformationFragment {
         mockk {
           every { create(AccountInformationViewModel::class.java) } returns mockViewModel
@@ -60,6 +61,11 @@ class AccountInformationFragmentTest {
         }
       }
     }
+  }
+
+  @After
+  fun tearDown() {
+    scenario.close()
   }
 
   @Test

--- a/simplified-cardcreator/src/test/kotlin/org/nypl/simplified/cardcreator/ui/ConfirmationFragmentTest.kt
+++ b/simplified-cardcreator/src/test/kotlin/org/nypl/simplified/cardcreator/ui/ConfirmationFragmentTest.kt
@@ -116,7 +116,6 @@ class ConfirmationFragmentTest {
       }
     }
     if (!finishing) scenario.close()
-    scenario.close()
   }
 
   @Test

--- a/simplified-cardcreator/src/test/kotlin/org/nypl/simplified/cardcreator/ui/ConfirmationFragmentTest.kt
+++ b/simplified-cardcreator/src/test/kotlin/org/nypl/simplified/cardcreator/ui/ConfirmationFragmentTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.fail
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
@@ -61,7 +62,7 @@ class ConfirmationFragmentTest {
 
   @Before
   fun setUp() {
-    MockKAnnotations.init(this)
+    MockKAnnotations.init(this, relaxed = true)
 
     mockkConstructor(Cache::class)
     mockkConstructor(ConfirmationViewModelFactory::class)
@@ -88,6 +89,11 @@ class ConfirmationFragmentTest {
         "name" to "testName"
       ),
     )
+  }
+
+  @After
+  fun tearDown() {
+    scenario.close()
   }
 
   @Test

--- a/simplified-ui-accounts/src/test/kotlin/org/nypl/simplified/ui/accounts/AccountDetailFragmentTest.kt
+++ b/simplified-ui-accounts/src/test/kotlin/org/nypl/simplified/ui/accounts/AccountDetailFragmentTest.kt
@@ -72,7 +72,7 @@ class AccountDetailFragmentTest {
 
   @Before
   fun setUp() {
-    MockKAnnotations.init(this)
+    MockKAnnotations.init(this, relaxed = true)
     Intents.init()
 
     val testCardCreatorContract = CardCreatorContract(
@@ -167,6 +167,7 @@ class AccountDetailFragmentTest {
   @After
   fun tearDown() {
     Intents.release()
+    scenario.close()
   }
 
   @Test

--- a/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogBookDetailFragmentTest.kt
+++ b/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogBookDetailFragmentTest.kt
@@ -15,6 +15,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -86,6 +87,11 @@ class CatalogBookDetailFragmentTest {
       fragmentArgs = bundleOf(CatalogBookDetailFragment.PARAMETERS_ID to params),
       themeResId = R.style.SimplifiedTheme_NoActionBar
     )
+  }
+
+  @After
+  fun tearDown() {
+    scenario.close()
   }
 
   @Test

--- a/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogFeedFragmentTest.kt
+++ b/simplified-ui-catalog/src/test/kotlin/org/nypl/simplified/ui/catalog/CatalogFeedFragmentTest.kt
@@ -44,6 +44,7 @@ import org.hamcrest.Matcher
 import org.hamcrest.core.AllOf.allOf
 import org.hamcrest.core.IsEqual.equalTo
 import org.hamcrest.core.IsNot.not
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -65,6 +66,7 @@ import org.nypl.simplified.ui.catalog.RecyclerViewEspressoUtils.atPositionOnView
 import org.nypl.simplified.ui.catalog.RecyclerViewEspressoUtils.hasAdapterItemCount
 import org.nypl.simplified.ui.catalog.withoutGroups.BookItem
 import org.nypl.simplified.ui.screen.ScreenSizeInformationType
+import org.robolectric.annotation.Config
 import java.net.URI
 
 @ExperimentalCoroutinesApi
@@ -90,7 +92,7 @@ class CatalogFeedFragmentTest {
 
   @Before
   fun setUp() {
-    MockKAnnotations.init(this)
+    MockKAnnotations.init(this, relaxed = true)
 
     // Mock service directory to return mocked services
     mockkObject(Services)
@@ -141,6 +143,11 @@ class CatalogFeedFragmentTest {
       fragmentArgs = bundleOf(CatalogFeedFragment.PARAMETERS_ID to catalogFeedArguments),
       themeResId = R.style.SimplifiedTheme_NoActionBar
     )
+  }
+
+  @After
+  fun tearDown() {
+    scenario.close()
   }
 
   @Test


### PR DESCRIPTION
**What's this do?**
This PR does a few minor upgrades to help improve our Robolectric tests.

Such as...

- Bump Gradle and AGP version
- Upgrade Robolectric to latest version
- Upgrade AndroidX Fragment to 1.4+ for Closeable FragmentScenarios
- Invoke close() for scenarios in After block to help clean up smoothly

**Why are we doing this? (w/ JIRA link if applicable)**
These changes are a result of investigating some seemingly slow Robolectric tests. It turns out the particular tests weren't actually slow, but were instead just reporting the overhead cost of starting up the test suite. That overhead cost isn't great but it is expected and seems generally reasonable for Robolectric. 

https://jira.nypl.org/browse/SMA-398

**How should this be tested? / Do these changes have associated tests?**
There are no new added tests but existing tests can be run with these changes.

**Dependencies for merging? Releasing to production?**
Platform dependencies have already been merged.

**Has the application documentation been updated for these changes?**
No documentation changes needed.

**Did someone actually run this code to verify it works?**
Ran tests locally on my development machine. 
