### PR TITLE
SMA-395: Spike - Investigate a Github Actions-Only CI/CD pipeline

### DIFF
--- a/.github/workflows/open-ebooks.yml
+++ b/.github/workflows/open-ebooks.yml
@@ -1,0 +1,83 @@
+name: Open eBooks Build, Test, & Distribute
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Reposistory
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: Set Up Credentials
+        env:
+          NYPL_S3_ACCESS_KEY: ${{ secrets.NYPL_S3_ACCESS_KEY }}
+          NYPL_S3_SECRET_ACCESS_KEY: ${{ secrets.NYPL_S3_SECRET_ACCESS_KEY }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_CENTRAL_STAGING_PROFILE_ID: 'af061f5afba777'
+          MAVEN_CENTRAL_SIGNING_KEY_ID: 'Library Simplified'
+          NYPL_GITHUB_ACCESS_TOKEN: ${{ secrets.NYPL_GITHUB_ACCESS_TOKEN }}
+        run: .ci/ci-credentials.sh
+
+      - name: Build
+        env:
+          NYPL_S3_ACCESS_KEY:               ${{ secrets.NYPL_S3_ACCESS_KEY }}
+          NYPL_S3_SECRET_ACCESS_KEY:        ${{ secrets.NYPL_S3_SECRET_ACCESS_KEY }}
+          MAVEN_CENTRAL_USERNAME:           ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD:           ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_CENTRAL_STAGING_PROFILE_ID: 'af061f5afba777'
+          MAVEN_CENTRAL_SIGNING_KEY_ID:     'Library Simplified'
+          NYPL_GITHUB_ACCESS_TOKEN:         ${{ secrets.NYPL_GITHUB_ACCESS_TOKEN }}
+        run: .ci/ci-build.sh normal
+
+      - name: Upload APK file
+        uses: actions/upload-artifact@master
+        with:
+          name: openebooks-release.apk
+          path: simplified-app-openebooks/build/outputs/apk/release/
+
+  unit_tests:
+    needs: [ build ]
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - name: Checkout Reposistory
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: Run tests
+        run: ./gradlew clean testDebug
+
+  distribute:
+    needs: [ unit_tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@main
+        with:
+          name: openebooks-release.apk
+
+      - name: Upload APK to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{secrets.OPENEBOOKS_FIREBASE_APP_ID}}
+          token: ${{secrets.FIREBASE_TOKEN}}
+          groups: openebooks-qa
+          file: openebooks-release.apk

--- a/.github/workflows/open-ebooks.yml
+++ b/.github/workflows/open-ebooks.yml
@@ -61,16 +61,14 @@ jobs:
           java-version: 11
 
       - name: Run tests
-        run: ./gradlew clean testDebug
+        run: ./gradlew clean testRelease
 
   distribute:
     needs: [ unit_tests ]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - uses: actions/download-artifact@main
+      - name: Download APK
+        uses: actions/download-artifact@main
         with:
           name: openebooks-release.apk
 

--- a/.github/workflows/simplye.yml
+++ b/.github/workflows/simplye.yml
@@ -61,16 +61,14 @@ jobs:
           java-version: 11
 
       - name: Run tests
-        run: ./gradlew clean testDebug
+        run: ./gradlew clean testRelease
 
   distribute:
     needs: [ unit_tests ]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - uses: actions/download-artifact@main
+      - name: Download APK
+        uses: actions/download-artifact@main
         with:
           name: simplye-release.apk
 

--- a/.github/workflows/simplye.yml
+++ b/.github/workflows/simplye.yml
@@ -1,0 +1,84 @@
+name: SimplyE Build, Test, & Distribute
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Reposistory
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: Set Up Credentials
+        env:
+          NYPL_S3_ACCESS_KEY: ${{ secrets.NYPL_S3_ACCESS_KEY }}
+          NYPL_S3_SECRET_ACCESS_KEY: ${{ secrets.NYPL_S3_SECRET_ACCESS_KEY }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_CENTRAL_STAGING_PROFILE_ID: 'af061f5afba777'
+          MAVEN_CENTRAL_SIGNING_KEY_ID: 'Library Simplified'
+          NYPL_GITHUB_ACCESS_TOKEN: ${{ secrets.NYPL_GITHUB_ACCESS_TOKEN }}
+        run: .ci/ci-credentials.sh
+
+      - name: Build
+        env:
+          NYPL_S3_ACCESS_KEY:               ${{ secrets.NYPL_S3_ACCESS_KEY }}
+          NYPL_S3_SECRET_ACCESS_KEY:        ${{ secrets.NYPL_S3_SECRET_ACCESS_KEY }}
+          MAVEN_CENTRAL_USERNAME:           ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD:           ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_CENTRAL_STAGING_PROFILE_ID: 'af061f5afba777'
+          MAVEN_CENTRAL_SIGNING_KEY_ID:     'Library Simplified'
+          NYPL_GITHUB_ACCESS_TOKEN:         ${{ secrets.NYPL_GITHUB_ACCESS_TOKEN }}
+        run: .ci/ci-build.sh normal
+
+      - name: Upload APK file
+        uses: actions/upload-artifact@master
+        with:
+          name: simplye-release.apk
+          path: simplified-app-simplye/build/outputs/apk/release/
+
+  unit_tests:
+    needs: [ build ]
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - name: Checkout Reposistory
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: Run tests
+        run: ./gradlew clean testDebug
+
+  distribute:
+    needs: [ unit_tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@main
+        with:
+          name: simplye-release.apk
+
+      - name: Upload apk to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{secrets.SIMPLYE_FIREBASE_APP_ID}}
+          token: ${{secrets.FIREBASE_TOKEN}}
+          groups: simplye-qa
+          file: simplye-release.apk
+


### PR DESCRIPTION
**What's this do?**

- [x] Adds new manual trigger for distributing builds to Firebase.
- [x] Separates build process for Open eBooks and SimplyE

**Why are we doing this? (w/ JIRA link if applicable)**
[SMA-395: Investigate a Github Actions-Only CI/CD pipeline](https://jira.nypl.org/browse/SMA-395)

**How should this be tested? / Do these changes have associated tests?**
Trigger manual build for Github.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a


