### PR TITLE
Updated platform repo

### DIFF
--- a/.ci-local/check-libraries.txt
+++ b/.ci-local/check-libraries.txt
@@ -37,8 +37,6 @@
 # com.fasterxml.jackson.module:jackson-module-kotlin
 # com.github.ChuckerTeam.Chucker:library
 # com.github.akarnokd:rxjava2-extensions
-# com.github.edrlab.nanohttpd:nanohttpd
-# com.github.edrlab.nanohttpd:nanohttpd-nanolets
 # com.github.qnga:BottomNavigator
 # com.github.readium:r2-opds-kotlin
 # com.github.readium:r2-shared-kotlin

--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,21 @@ subprojects { project ->
       task.onlyIf { nyplDrmEnabled }
     }
   }
+  // This resolution strategy is required in order to pick up Readium's fork of nanohttpd.
+  // This must remain until will update Readium. See migration guide: https://github.com/readium/kotlin-toolkit/releases/tag/2.2.1
+  if (nyplDrmEnabled || !nyplDrmRequired) {
+    project.configurations.all {
+      resolutionStrategy {
+        dependencySubstitution {
+          all { DependencySubstitution dependency ->
+            if (dependency.requested instanceof ModuleComponentSelector && dependency.requested.group == 'com.github.edrlab.nanohttpd') {
+              dependency.useTarget ('com.github.readium.nanohttpd:' + dependency.requested.module + ':' + dependency.requested.version, 'because nanohttpd ownership changed from edrlab to readium')
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/build_apk.gradle
+++ b/build_apk.gradle
@@ -140,4 +140,14 @@ configurations.all {
   final String version = dependency.versionConstraint.requiredVersion
   final String dependencyString = "$module:$version"
   resolutionStrategy.force dependencyString
+  // This resolution strategy is required in order to pick up Readium's fork of nanohttpd.
+  // This must remain until will update Readium. See migration guide: https://github.com/readium/kotlin-toolkit/releases/tag/2.2.1
+  resolutionStrategy.eachDependency {
+    if (requested.group == "com.github.edrlab.nanohttpd" && requested.name == "nanohttpd") {
+      useTarget("com.github.readium.nanohttpd:nanohttpd:master-SNAPSHOT")
+    }
+    if (requested.group == "com.github.edrlab.nanohttpd" && requested.name == "nanohttpd-nanolets") {
+      useTarget("com.github.readium.nanohttpd:nanohttpd-nanolets:master-SNAPSHOT")
+    }
+  }
 }

--- a/build_apk.gradle
+++ b/build_apk.gradle
@@ -140,14 +140,4 @@ configurations.all {
   final String version = dependency.versionConstraint.requiredVersion
   final String dependencyString = "$module:$version"
   resolutionStrategy.force dependencyString
-  // This resolution strategy is required in order to pick up Readium's fork of nanohttpd.
-  // This must remain until will update Readium. See migration guide: https://github.com/readium/kotlin-toolkit/releases/tag/2.2.1
-  resolutionStrategy.eachDependency {
-    if (requested.group == "com.github.edrlab.nanohttpd" && requested.name == "nanohttpd") {
-      useTarget("com.github.readium.nanohttpd:nanohttpd:master-SNAPSHOT")
-    }
-    if (requested.group == "com.github.edrlab.nanohttpd" && requested.name == "nanohttpd-nanolets") {
-      useTarget("com.github.readium.nanohttpd:nanohttpd-nanolets:master-SNAPSHOT")
-    }
-  }
 }


### PR DESCRIPTION
**What's this do?**
EDR Labs deleted there nanohttpd repo in which us and Readium were using as a dependency. See: https://github.com/NYPL-Simplified/Simplified-Android-Platform/pull/10

**Why are we doing this? (w/ JIRA link if applicable)**
@roywatson noticed builds were failing

**How should this be tested? / Do these changes have associated tests?**
1. Pull branch
2. Ensure you can build locally

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
TBA
