### PR TITLE
Update target sdk and error screen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,9 @@ plugins {
 
 ext {
   android_build_tools_version = "30.0.2"
-  android_compile_sdk_version = 31
+  android_compile_sdk_version = 33
   android_min_sdk_version = 24
-  android_target_sdk_version = 31
+  android_target_sdk_version = 33
 
   // Required for some dependencies only available from our private S3
   //

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
@@ -107,7 +107,7 @@ class LocationFragment : Fragment(), LocationListener {
       if (isNewYork || locationMock != null) {
         locationMock?.let { location ->
           activityModel.userLocationAddress =
-            geocoder.getFromLocation(location.latitude, location.longitude, 1)[0]
+            geocoder.getFromLocation(location.latitude, location.longitude, 1)?.get(0)
         }
 
         logger.debug("User navigated to the next screen")
@@ -230,7 +230,7 @@ class LocationFragment : Fragment(), LocationListener {
 
     try {
       if (location != null) {
-        address = geocoder.getFromLocation(location.latitude, location.longitude, maxResults)[0]
+        address = geocoder.getFromLocation(location.latitude, location.longitude, maxResults)!![0]
         logger.debug("Region is: ${address.adminArea} ${address.countryCode} ")
         binding.regionEt.setText("${address.adminArea} ${address.countryCode}", TextView.BufferType.EDITABLE)
 
@@ -292,7 +292,7 @@ class LocationFragment : Fragment(), LocationListener {
     val address: Address?
 
     try {
-      address = geocoder.getFromLocation(location.latitude, location.longitude, maxResults)[0]
+      address = geocoder.getFromLocation(location.latitude, location.longitude, maxResults)!![0]
       logger.debug("Region is: ${address.adminArea} ${address.countryCode} ")
       binding.regionEt.setText("${address.adminArea} ${address.countryCode}", TextView.BufferType.EDITABLE)
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryFragment.kt
@@ -192,12 +192,12 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
     })
 
     search.setOnActionExpandListener(object : OnActionExpandListener {
-      override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
+      override fun onMenuItemActionExpand(item: MenuItem): Boolean {
         // Do nothing
         return true
       }
 
-      override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
+      override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
         this@AccountListRegistryFragment.accountListAdapter.resetFilter()
         return true
       }

--- a/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageFragment.kt
+++ b/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageFragment.kt
@@ -6,14 +6,12 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.StyleSpan
 import android.view.View
-import android.widget.Button
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import org.nypl.simplified.android.ktx.supportActionBar
-import org.nypl.simplified.reports.Reports
 import org.slf4j.LoggerFactory
 
 /**
@@ -49,7 +47,6 @@ class ErrorPageFragment : Fragment(R.layout.error_page) {
   private lateinit var errorDetails: TextView
   private lateinit var errorStepsList: RecyclerView
   private lateinit var parameters: ErrorPageParameters
-  private lateinit var sendButton: Button
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
@@ -58,8 +55,6 @@ class ErrorPageFragment : Fragment(R.layout.error_page) {
       view.findViewById(R.id.errorDetails)
     this.errorStepsList =
       view.findViewById(R.id.errorSteps)
-    this.sendButton =
-      view.findViewById(R.id.errorSendButton)
 
     this.parameters =
       this.arguments!!.getSerializable(PARAMETERS_ID)
@@ -97,18 +92,6 @@ class ErrorPageFragment : Fragment(R.layout.error_page) {
   override fun onStart() {
     super.onStart()
     this.configureToolbar()
-
-    this.sendButton.isEnabled = true
-    this.sendButton.setOnClickListener {
-      this.sendButton.isEnabled = false
-
-      Reports.sendReportsDefault(
-        context = requireContext(),
-        address = parameters.emailAddress,
-        subject = parameters.subject,
-        body = parameters.report
-      )
-    }
   }
 
   private fun configureToolbar() {

--- a/simplified-ui-errorpage/src/main/res/layout/error_page.xml
+++ b/simplified-ui-errorpage/src/main/res/layout/error_page.xml
@@ -53,14 +53,14 @@
     </LinearLayout>
   </androidx.core.widget.NestedScrollView>
 
-  <Button
-    android:id="@+id/errorSendButton"
+  <TextView
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginStart="32dp"
     android:layout_marginTop="16dp"
     android:layout_marginEnd="32dp"
     android:layout_marginBottom="16dp"
-    android:text="@string/errorSendReport" />
+    android:text="Contact the email listed under your library's account page (under Settings/Accounts) for assistance."
+    />
 </LinearLayout>
 


### PR DESCRIPTION
**What's this do?**
Update target and compile sdk to prep for Google policy changes. In addition, this also updates the error reporting screen since the current "Report Issue" button sends the report to a generic, untracked email, we're replacing that button with some text to direct the user to their local library help email.

<img width=300 src="https://github.com/NYPL-Simplified/Simplified-Android-Core/assets/1281199/2961d0de-37ff-4253-b4e7-357a417c538f"/>
