### PR TITLE
Add expiration for open access books

### DIFF
--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryParser.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryParser.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -164,7 +165,16 @@ public final class OPDSAcquisitionFeedEntryParser implements OPDSAcquisitionFeed
 
     findAcquisitionAuthors(element, entry_builder);
     entry_builder.setPublisherOption(findPublisher(element));
-    entry_builder.setDistribution(findDistribution(element));
+
+    String distribution = findDistribution(element);
+    entry_builder.setDistribution(distribution);
+    if ("Axis 360".equals(distribution)) {
+      DateTime end = DateTime.now().plusMonths(2);
+      entry_builder.setAvailability(
+        OPDSAvailabilityOpenAccess.get(revoke, Option.some(end))
+      );
+    }
+
     entry_builder.setPublishedOption(OPDSAtom.findPublished(element));
     entry_builder.setSummaryOption(
       OPDSXML.getFirstChildElementTextWithNameOptional(element, ATOM_URI, "summary"));
@@ -280,11 +290,7 @@ public final class OPDSAcquisitionFeedEntryParser implements OPDSAcquisitionFeed
             final OPDSAcquisition acquisition = new OPDSAcquisition(v, href, type, indirects);
             entry_builder.addAcquisition(acquisition);
 
-            if (v == Relation.ACQUISITION_OPEN_ACCESS) {
-              entry_builder.setAvailability(OPDSAvailabilityOpenAccess.get(revoke));
-            } else {
-              tryAvailability(entry_builder, link, revoke);
-            }
+            tryAvailability(entry_builder, link, revoke);
             break;
           }
         }
@@ -653,6 +659,8 @@ public final class OPDSAcquisitionFeedEntryParser implements OPDSAcquisitionFeed
           return OPDSAvailabilityLoanable.get();
         } else if (Relation.ACQUISITION_GENERIC.getUri().toString().equals(rel)) {
           return OPDSAvailabilityLoaned.get(start_date, end_date, revoke);
+        } else if (Relation.ACQUISITION_OPEN_ACCESS.getUri().toString().equals(rel)) {
+          return OPDSAvailabilityOpenAccess.get(revoke, end_date);
         }
       }
     }

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryParser.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryParser.java
@@ -165,16 +165,7 @@ public final class OPDSAcquisitionFeedEntryParser implements OPDSAcquisitionFeed
 
     findAcquisitionAuthors(element, entry_builder);
     entry_builder.setPublisherOption(findPublisher(element));
-
-    String distribution = findDistribution(element);
-    entry_builder.setDistribution(distribution);
-    if ("Axis 360".equals(distribution)) {
-      DateTime end = DateTime.now().plusMonths(2);
-      entry_builder.setAvailability(
-        OPDSAvailabilityOpenAccess.get(revoke, Option.some(end))
-      );
-    }
-
+    entry_builder.setDistribution(findDistribution(element));
     entry_builder.setPublishedOption(OPDSAtom.findPublished(element));
     entry_builder.setSummaryOption(
       OPDSXML.getFirstChildElementTextWithNameOptional(element, ATOM_URI, "summary"));

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAvailabilityOpenAccess.kt
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAvailabilityOpenAccess.kt
@@ -15,7 +15,8 @@ data class OPDSAvailabilityOpenAccess private constructor(
    * @return The revocation link, if any
    */
 
-  val revoke: OptionType<URI>
+  val revoke: OptionType<URI>,
+  private val endDate: OptionType<DateTime>
 ) : OPDSAvailabilityType {
 
   val endDateOrNull: DateTime?
@@ -30,7 +31,7 @@ data class OPDSAvailabilityOpenAccess private constructor(
    */
 
   override fun getEndDate(): OptionType<DateTime> {
-    return Option.none()
+    return this.endDate
   }
 
   override fun toString(): String {
@@ -57,10 +58,12 @@ data class OPDSAvailabilityOpenAccess private constructor(
      */
 
     @JvmStatic
+    @JvmOverloads
     operator fun get(
-      revoke: OptionType<URI>
+      revoke: OptionType<URI>,
+      endDate: OptionType<DateTime> = Option.none(),
     ): OPDSAvailabilityOpenAccess {
-      return OPDSAvailabilityOpenAccess(revoke)
+      return OPDSAvailabilityOpenAccess(revoke, endDate)
     }
   }
 }

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSJSONParser.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSJSONParser.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import one.irradia.mime.api.MIMEType;
@@ -176,7 +177,9 @@ public final class OPDSJSONParser implements OPDSJSONParserType {
           node, "open_access");
         final OptionType<URI> in_revoke =
           JSONParserUtilities.getURIOptional(n, "revoke");
-        return OPDSAvailabilityOpenAccess.get(in_revoke);
+        final OptionType<DateTime> in_end_date =
+          JSONParserUtilities.getTimestampOptional(n, "end_date");
+        return OPDSAvailabilityOpenAccess.get(in_revoke, in_end_date);
       }
 
       if (node.has("revoked")) {

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSJSONSerializer.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSJSONSerializer.java
@@ -174,6 +174,10 @@ public final class OPDSJSONSerializer implements OPDSJSONSerializerType {
               oh.put("revoke", uri.toString());
               return Unit.unit();
             });
+          a.getEndDate().map(t -> {
+            oh.put("end_date", fmt.print(t));
+            return Unit.unit();
+          });
           o.set("open_access", oh);
           return o;
         }


### PR DESCRIPTION
**What's this do?**
Adds an optional expiration date from the `until` field in the OPDS availability feed for Open Access publications. 
This change also updates the `BookSyncTask` to check for expired open access books and remove them from the device, as there is no loan feed to sync with. 

**Did someone actually run this code to verify it works?**
Yup!